### PR TITLE
intrusive_ptrと関連クラスをリネームします

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(Threads)
 include_directories(include)
 
 set(LIBRARY_SOURCE_FILES
-    include/eventkit/common/intrusive_ptr.h
+    include/eventkit/common/IntrusivePtr.h
     include/eventkit/common/IntrusiveObject.h
     include/eventkit/dispatch/detail/Semaphore.h
     include/eventkit/dispatch/DispatchQueue.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include_directories(include)
 
 set(LIBRARY_SOURCE_FILES
     include/eventkit/common/intrusive_ptr.h
-    include/eventkit/common/RefCountObject.h
+    include/eventkit/common/IntrusiveObject.h
     include/eventkit/dispatch/detail/Semaphore.h
     include/eventkit/dispatch/DispatchQueue.h
     include/eventkit/dispatch/detail/DispatchQueue-inl.h

--- a/include/eventkit/common/IntrusiveObject.h
+++ b/include/eventkit/common/IntrusiveObject.h
@@ -2,21 +2,21 @@
 // Created by Masahiko Tsujita on 2019/09/12.
 //
 
-#ifndef EVENTKIT_REFCOUNTOBJECT_H
-#define EVENTKIT_REFCOUNTOBJECT_H
+#ifndef EVENTKIT_INTRUSIVEOBJECT_H
+#define EVENTKIT_INTRUSIVEOBJECT_H
 
 #include <atomic>
 
 namespace ek {
 namespace common {
 
-class RefCountObject {
+class IntrusiveObject {
 public:
-    RefCountObject()
+    IntrusiveObject()
         : m_refCount(1) {
     }
     
-    virtual ~RefCountObject() = default;
+    virtual ~IntrusiveObject() = default;
     
     void ref() const {
         std::atomic_fetch_add_explicit(&m_refCount, 1u, std::memory_order_relaxed);
@@ -34,15 +34,15 @@ private:
     
 };
 
-inline void intrusive_ptr_ref(RefCountObject* pObj) {
+inline void intrusive_ptr_ref(IntrusiveObject* pObj) {
     pObj->ref();
 }
 
-inline void intrusive_ptr_unref(RefCountObject* pObj) {
+inline void intrusive_ptr_unref(IntrusiveObject* pObj) {
     pObj->unref();
 }
 
 }
 }
 
-#endif //EVENTKIT_REFCOUNTOBJECT_H
+#endif //EVENTKIT_INTRUSIVEOBJECT_H

--- a/include/eventkit/common/IntrusivePtr.h
+++ b/include/eventkit/common/IntrusivePtr.h
@@ -2,8 +2,8 @@
 // Created by Masahiko Tsujita on 2019/09/10.
 //
 
-#ifndef EVENTKIT_INTRUSIVE_PTR_H
-#define EVENTKIT_INTRUSIVE_PTR_H
+#ifndef EVENTKIT_INTRUSIVEPTR_H
+#define EVENTKIT_INTRUSIVEPTR_H
 
 #include <utility>
 
@@ -11,28 +11,28 @@ namespace ek {
 namespace common {
 
 template <typename T>
-class intrusive_ptr {
+class IntrusivePtr {
 public:
     
     using element_type = T;
     
-    intrusive_ptr()
+    IntrusivePtr()
         : m_p(nullptr) {
     }
     
     template <typename U>
-    explicit intrusive_ptr(U* p, bool add_ref = true)
+    explicit IntrusivePtr(U* p, bool add_ref = true)
         : m_p(p) {
         if (p != nullptr && add_ref) {
             intrusive_ptr_ref(p);
         }
     }
     
-    intrusive_ptr(std::nullptr_t)
+    IntrusivePtr(std::nullptr_t)
         : m_p(nullptr) {
     }
     
-    intrusive_ptr(const intrusive_ptr& rhs)
+    IntrusivePtr(const IntrusivePtr& rhs)
         : m_p(rhs.m_p) {
         if (m_p != nullptr) {
             intrusive_ptr_ref(m_p);
@@ -40,28 +40,28 @@ public:
     }
     
     template<class U>
-    intrusive_ptr(const intrusive_ptr<U>& rhs)
+    IntrusivePtr(const IntrusivePtr<U>& rhs)
         : m_p(rhs.m_p) {
         if (m_p != nullptr) {
             intrusive_ptr_ref(m_p);
         }
     }
     
-    intrusive_ptr(intrusive_ptr&& rhs)
+    IntrusivePtr(IntrusivePtr&& rhs)
         : m_p(rhs.m_p) {
         rhs.m_p = nullptr;
     }
     
     template<class U>
-    friend class intrusive_ptr;
+    friend class IntrusivePtr;
     
     template<class U>
-    intrusive_ptr(intrusive_ptr<U>&& rhs)
+    IntrusivePtr(IntrusivePtr<U>&& rhs)
         : m_p(rhs.m_p) {
         rhs.m_p = nullptr;
     }
     
-    intrusive_ptr& operator = (const intrusive_ptr& rhs) {
+    IntrusivePtr& operator = (const IntrusivePtr& rhs) {
         if (m_p != nullptr) {
             intrusive_ptr_unref(m_p);
         }
@@ -73,7 +73,7 @@ public:
     }
     
     template <typename U>
-    intrusive_ptr& operator = (const intrusive_ptr<U>& rhs) {
+    IntrusivePtr& operator = (const IntrusivePtr<U>& rhs) {
         if (m_p != nullptr) {
             intrusive_ptr_unref(m_p);
         }
@@ -84,7 +84,7 @@ public:
         return *this;
     }
     
-    intrusive_ptr& operator = (intrusive_ptr&& another) noexcept {
+    IntrusivePtr& operator = (IntrusivePtr&& another) noexcept {
         if (m_p != nullptr) {
             intrusive_ptr_unref(m_p);
         }
@@ -94,7 +94,7 @@ public:
     }
     
     template <typename U>
-    intrusive_ptr& operator = (intrusive_ptr<U>&& another) noexcept {
+    IntrusivePtr& operator = (IntrusivePtr<U>&& another) noexcept {
         if (m_p != nullptr) {
             intrusive_ptr_unref(m_p);
         }
@@ -103,7 +103,7 @@ public:
         return *this;
     }
     
-    ~intrusive_ptr() {
+    ~IntrusivePtr() {
         if (m_p != nullptr) {
             intrusive_ptr_unref(m_p);
         }
@@ -127,83 +127,83 @@ private:
 };
 
 template<class T, class U>
-inline bool operator == (const intrusive_ptr<T>& a, const intrusive_ptr<U>& b) {
+inline bool operator == (const IntrusivePtr<T>& a, const IntrusivePtr<U>& b) {
     return a.get() == b.get();
 }
 
 template<class T, class U>
-inline bool operator != (const intrusive_ptr<T>& a, const intrusive_ptr<U>& b) {
+inline bool operator != (const IntrusivePtr<T>& a, const IntrusivePtr<U>& b) {
     return a.get() != b.get();
 }
 
 template<class T, class U>
-inline bool operator == (const intrusive_ptr<T>& a, U* b) {
+inline bool operator == (const IntrusivePtr<T>& a, U* b) {
     return a.get() == b;
 }
 
 template<class T, class U>
-inline bool operator != (const intrusive_ptr<T>& a, U * b) {
+inline bool operator != (const IntrusivePtr<T>& a, U * b) {
     return a.get() != b;
 }
 
 template<class T, class U>
-inline bool operator == (T* a, const intrusive_ptr<U>& b) {
+inline bool operator == (T* a, const IntrusivePtr<U>& b) {
     return a == b.get();
 }
 
 template<class T, class U>
-inline bool operator != (T * a, const intrusive_ptr<U>& b) {
+inline bool operator != (T * a, const IntrusivePtr<U>& b) {
     return a != b.get();
 }
 
 template<class T>
-inline bool operator == (const intrusive_ptr<T>& p, std::nullptr_t) {
+inline bool operator == (const IntrusivePtr<T>& p, std::nullptr_t) {
     return p.get() == nullptr;
 }
 
 template<class T>
-inline bool operator == (std::nullptr_t, const intrusive_ptr<T>& p) {
+inline bool operator == (std::nullptr_t, const IntrusivePtr<T>& p) {
     return p.get() == nullptr;
 }
 
 template<class T>
-inline bool operator != (const intrusive_ptr<T>& p, std::nullptr_t) {
+inline bool operator != (const IntrusivePtr<T>& p, std::nullptr_t) {
     return p.get() != nullptr;
 }
 
 template<class T>
-inline bool operator != (std::nullptr_t, const intrusive_ptr<T>& p) {
+inline bool operator != (std::nullptr_t, const IntrusivePtr<T>& p) {
     return p.get() != nullptr;
 }
 
 template<class T>
-T * get_pointer(const intrusive_ptr<T>& p) {
+T * get_pointer(const IntrusivePtr<T>& p) {
     return p.get();
 }
 
 template<class T, class U>
-intrusive_ptr<T> static_pointer_cast(const intrusive_ptr<U>& p) {
+IntrusivePtr<T> static_pointer_cast(const IntrusivePtr<U>& p) {
     return static_cast<T*>(p.get());
 }
 
 template<class T, class U>
-intrusive_ptr<T> const_pointer_cast(const intrusive_ptr<U>& p) {
+IntrusivePtr<T> const_pointer_cast(const IntrusivePtr<U>& p) {
     return const_cast<T*>(p.get());
 }
 
 #if defined(EVENTKIT_ENABLE_RTTI)
 template<class T, class U>
-intrusive_ptr<T> dynamic_pointer_cast(const intrusive_ptr<U>& p) {
+IntrusivePtr<T> dynamic_pointer_cast(const IntrusivePtr<U>& p) {
     return dynamic_cast<T*>(p.get());
 }
 #endif
 
 template <typename T, typename ...Args>
-intrusive_ptr<T> make_intrusive(Args&& ...args) {
-    return intrusive_ptr<T>(new T (std::forward<Args>(args)...), false);
+IntrusivePtr<T> make_intrusive(Args&& ...args) {
+    return IntrusivePtr<T>(new T (std::forward<Args>(args)...), false);
 }
 
 }
 }
 
-#endif //EVENTKIT_INTRUSIVE_PTR_H
+#endif //EVENTKIT_INTRUSIVEPTR_H

--- a/include/eventkit/dispatch/DispatchQueue.h
+++ b/include/eventkit/dispatch/DispatchQueue.h
@@ -9,12 +9,12 @@
 #include <list>
 #include <queue>
 #include <eventkit/dispatch/RunLoop.h>
-#include <eventkit/common/RefCountObject.h>
+#include <eventkit/common/IntrusiveObject.h>
 
 namespace ek {
 namespace dispatch {
 
-class DispatchItem : public ek::common::RefCountObject {
+class DispatchItem : public ek::common::IntrusiveObject {
 public:
     virtual ~DispatchItem() = default;
 
@@ -38,7 +38,7 @@ private:
 
 };
 
-class DispatchQueue : public ek::common::RefCountObject {
+class DispatchQueue : public ek::common::IntrusiveObject {
 public:
 
     friend class RunLoop;

--- a/include/eventkit/dispatch/DispatchQueue.h
+++ b/include/eventkit/dispatch/DispatchQueue.h
@@ -48,7 +48,7 @@ public:
 
 private:
 
-    void dispatchItemAsync(const ek::common::intrusive_ptr<DispatchItem>& pTask);
+    void dispatchItemAsync(const ek::common::IntrusivePtr<DispatchItem>& pTask);
 
     void fire();
 
@@ -56,7 +56,7 @@ private:
 
 private:
     std::mutex m_mutex;
-    std::queue<ek::common::intrusive_ptr<DispatchItem>, std::list<ek::common::intrusive_ptr<DispatchItem>>> m_queue;
+    std::queue<ek::common::IntrusivePtr<DispatchItem>, std::list<ek::common::IntrusivePtr<DispatchItem>>> m_queue;
     RunLoop* m_pRunLoop;
 
 };

--- a/include/eventkit/dispatch/RunLoop.h
+++ b/include/eventkit/dispatch/RunLoop.h
@@ -7,7 +7,7 @@
 
 #include <list>
 #include <eventkit/dispatch/detail/Semaphore.h>
-#include <eventkit/common/intrusive_ptr.h>
+#include <eventkit/common/IntrusivePtr.h>
 
 namespace ek {
 namespace dispatch {
@@ -25,7 +25,7 @@ public:
 
     void run();
 
-    void addDispatchQueue(const ek::common::intrusive_ptr<DispatchQueue>& pQueue);
+    void addDispatchQueue(const ek::common::IntrusivePtr<DispatchQueue>& pQueue);
 
     void removeDispatchQueue(DispatchQueue* pQueue);
 
@@ -38,7 +38,7 @@ private:
 
 private:
     detail::Semaphore m_semaphore;
-    std::list<ek::common::intrusive_ptr<DispatchQueue>> m_dispatchQueues;
+    std::list<ek::common::IntrusivePtr<DispatchQueue>> m_dispatchQueues;
 
 };
 

--- a/include/eventkit/promise/Promise.h
+++ b/include/eventkit/promise/Promise.h
@@ -19,7 +19,7 @@ class Promise;
 
 namespace detail {
 template <typename T, typename E>
-ek::promise::Promise<T, E> make_promise(const ek::common::intrusive_ptr<ek::promise::detail::PromiseCore<T, E>>& pCore);
+ek::promise::Promise<T, E> make_promise(const ek::common::IntrusivePtr<ek::promise::detail::PromiseCore<T, E>>& pCore);
 }
 
 template <typename T, typename E>
@@ -28,7 +28,7 @@ private:
     using Core = detail::PromiseCore<T, E>;
     
     template <typename U, typename F>
-    friend ek::promise::Promise<U, F> detail::make_promise(const ek::common::intrusive_ptr<ek::promise::detail::PromiseCore<U, F>>& pCore);
+    friend ek::promise::Promise<U, F> detail::make_promise(const ek::common::IntrusivePtr<ek::promise::detail::PromiseCore<U, F>>& pCore);
 
 public:
     using Value = T;
@@ -56,7 +56,7 @@ public:
         return Promise(pCore);
     }
 
-    void pipe(const ek::common::intrusive_ptr<ResultObserver<T, E>>& handler) const {
+    void pipe(const ek::common::IntrusivePtr<ResultObserver<T, E>>& handler) const {
         m_pCore->addHandler(handler);
     }
 
@@ -84,12 +84,12 @@ public:
 
 private:
 
-    explicit Promise(const ek::common::intrusive_ptr<Core>& pCore)
+    explicit Promise(const ek::common::IntrusivePtr<Core>& pCore)
         : m_pCore(pCore) {
     }
 
 private:
-    ek::common::intrusive_ptr<Core> m_pCore;
+    ek::common::IntrusivePtr<Core> m_pCore;
 
 };
 

--- a/include/eventkit/promise/Resolver.h
+++ b/include/eventkit/promise/Resolver.h
@@ -7,7 +7,7 @@
 
 #include <memory>
 #include <eventkit/promise/Result.h>
-#include <eventkit/common/intrusive_ptr.h>
+#include <eventkit/common/IntrusivePtr.h>
 
 namespace ek {
 namespace promise {
@@ -36,7 +36,7 @@ private:
 
 public:
 
-    explicit Resolver(const ek::common::intrusive_ptr<Core>& pCore)
+    explicit Resolver(const ek::common::IntrusivePtr<Core>& pCore)
         : m_pCore(pCore) {
     }
 
@@ -61,7 +61,7 @@ public:
     }
 
 private:
-    ek::common::intrusive_ptr<Core> m_pCore;
+    ek::common::IntrusivePtr<Core> m_pCore;
 
 };
 
@@ -72,7 +72,7 @@ private:
 
 public:
 
-    explicit Fulfiller(const ek::common::intrusive_ptr<Core>& pCore)
+    explicit Fulfiller(const ek::common::IntrusivePtr<Core>& pCore)
         : m_pCore(pCore) {
     }
 
@@ -81,7 +81,7 @@ public:
     }
 
 private:
-    ek::common::intrusive_ptr<Core> m_pCore;
+    ek::common::IntrusivePtr<Core> m_pCore;
 
 };
 
@@ -92,7 +92,7 @@ private:
 
 public:
 
-    explicit Rejecter(const ek::common::intrusive_ptr<Core>& pCore)
+    explicit Rejecter(const ek::common::IntrusivePtr<Core>& pCore)
         : m_pCore(pCore) {
     }
 
@@ -101,7 +101,7 @@ public:
     }
 
 private:
-    ek::common::intrusive_ptr<Core> m_pCore;
+    ek::common::IntrusivePtr<Core> m_pCore;
 
 };
 

--- a/include/eventkit/promise/ResultObserver.h
+++ b/include/eventkit/promise/ResultObserver.h
@@ -7,7 +7,7 @@
 
 #include <eventkit/promise/Result.h>
 #include <eventkit/promise/Promise.h>
-#include <eventkit/common/RefCountObject.h>
+#include <eventkit/common/IntrusiveObject.h>
 
 namespace ek {
 namespace promise {

--- a/include/eventkit/promise/detail/Promise-inl.h
+++ b/include/eventkit/promise/detail/Promise-inl.h
@@ -12,7 +12,7 @@ namespace promise {
 namespace detail {
 
 template <typename T, typename E>
-ek::promise::Promise<T, E> make_promise(const ek::common::intrusive_ptr<ek::promise::detail::PromiseCore<T, E>>& pCore) {
+ek::promise::Promise<T, E> make_promise(const ek::common::IntrusivePtr<ek::promise::detail::PromiseCore<T, E>>& pCore) {
     return ek::promise::Promise<T, E>(pCore);
 }
 

--- a/include/eventkit/promise/detail/PromiseCore.h
+++ b/include/eventkit/promise/detail/PromiseCore.h
@@ -29,14 +29,14 @@ public:
         }
         m_isResolved = true;
         m_result = result;
-        std::list<ek::common::intrusive_ptr<Handler>> handlers = std::move(m_handlers);
+        std::list<ek::common::IntrusivePtr<Handler>> handlers = std::move(m_handlers);
         lock.unlock();
         for (const auto& pHandler : handlers) {
             pHandler->onResult(m_result);
         }
     }
 
-    void addHandler(const ek::common::intrusive_ptr<Handler>& handler) {
+    void addHandler(const ek::common::IntrusivePtr<Handler>& handler) {
         std::lock_guard<std::mutex> lock(m_mutex);
         if (!m_isResolved) {
             m_handlers.push_back(handler);
@@ -57,7 +57,7 @@ private:
     std::mutex m_mutex;
     bool m_isResolved;
     Result<T, E> m_result;
-    std::list<ek::common::intrusive_ptr<Handler>> m_handlers;
+    std::list<ek::common::IntrusivePtr<Handler>> m_handlers;
 };
 
 }

--- a/include/eventkit/promise/detail/PromiseCore.h
+++ b/include/eventkit/promise/detail/PromiseCore.h
@@ -16,7 +16,7 @@ namespace promise {
 namespace detail {
 
 template <typename T, typename E>
-class PromiseCore : public ResultObserver<T, E>, public ek::common::RefCountObject {
+class PromiseCore : public ResultObserver<T, E>, public ek::common::IntrusiveObject {
 public:
     using Handler = ResultObserver<T, E>;
 
@@ -46,11 +46,11 @@ public:
     }
     
     virtual void ref() const override {
-        ek::common::RefCountObject::ref();
+        ek::common::IntrusiveObject::ref();
     }
     
     virtual void unref() const override {
-        ek::common::RefCountObject::unref();
+        ek::common::IntrusiveObject::unref();
     }
 
 private:

--- a/include/eventkit/promise/detail/RecoverTransformationCore.h
+++ b/include/eventkit/promise/detail/RecoverTransformationCore.h
@@ -34,12 +34,12 @@ public:
         }
     }
     
-    ek::common::intrusive_ptr<PromiseCore<T, F>> asCore() {
-        return ek::common::intrusive_ptr<PromiseCore<T, F>>(static_cast<PromiseCore<T, F>*>(this));
+    ek::common::IntrusivePtr<PromiseCore < T, F>> asCore() {
+        return ek::common::IntrusivePtr<PromiseCore<T, F>>(static_cast<PromiseCore<T, F>*>(this));
     }
     
-    ek::common::intrusive_ptr<ResultObserver<T, E>> asHandler() {
-        return ek::common::intrusive_ptr<ResultObserver<T, E>>(static_cast<ResultObserverMultipleInheritanceHelper<T, E>*>(this));
+    ek::common::IntrusivePtr<ResultObserver < T, E>> asHandler() {
+        return ek::common::IntrusivePtr<ResultObserver<T, E>>(static_cast<ResultObserverMultipleInheritanceHelper<T, E>*>(this));
     }
     
     virtual void ref(result_observer_multiple_inheritance_helper_tag_t) const override {

--- a/include/eventkit/promise/detail/ResultObserver-inl.h
+++ b/include/eventkit/promise/detail/ResultObserver-inl.h
@@ -37,7 +37,7 @@ private:
 };
 
 template <typename T, typename E, typename Function>
-auto make_function_observer(Function&& function) -> ek::common::intrusive_ptr<ResultObserver<T, E>> {
+auto make_function_observer(Function&& function) -> ek::common::IntrusivePtr<ResultObserver < T, E>> {
     return ek::common::make_intrusive<FunctionResultObserver<T, E, std::decay_t<Function>>>(std::forward<Function>(function));
 }
 

--- a/include/eventkit/promise/detail/ResultObserver-inl.h
+++ b/include/eventkit/promise/detail/ResultObserver-inl.h
@@ -10,7 +10,7 @@ namespace promise {
 namespace detail {
 
 template <typename T, typename E, typename Function>
-class FunctionResultObserver : public ResultObserver<T, E>, public ek::common::RefCountObject {
+class FunctionResultObserver : public ResultObserver<T, E>, public ek::common::IntrusiveObject {
 public:
     template <typename F>
     explicit FunctionResultObserver(F&& function)
@@ -24,11 +24,11 @@ public:
     }
     
     virtual void ref() const override {
-        ek::common::RefCountObject::ref();
+        ek::common::IntrusiveObject::ref();
     }
     
     virtual void unref() const override {
-        ek::common::RefCountObject::unref();
+        ek::common::IntrusiveObject::unref();
     }
 
 private:

--- a/include/eventkit/promise/detail/ThenTransformationCore.h
+++ b/include/eventkit/promise/detail/ThenTransformationCore.h
@@ -34,12 +34,12 @@ public:
         }
     }
     
-    ek::common::intrusive_ptr<PromiseCore<U, E>> asCore() {
-        return ek::common::intrusive_ptr<PromiseCore<U, E>>(static_cast<PromiseCore<U, E>*>(this));
+    ek::common::IntrusivePtr<PromiseCore<U, E>> asCore() {
+        return ek::common::IntrusivePtr<PromiseCore<U, E>>(static_cast<PromiseCore<U, E>*>(this));
     }
     
-    ek::common::intrusive_ptr<ResultObserver<T, E>> asHandler() {
-        return ek::common::intrusive_ptr<ResultObserver<T, E>>(static_cast<ResultObserverMultipleInheritanceHelper<T, E>*>(this));
+    ek::common::IntrusivePtr<ResultObserver<T, E>> asHandler() {
+        return ek::common::IntrusivePtr<ResultObserver<T, E>>(static_cast<ResultObserverMultipleInheritanceHelper<T, E>*>(this));
     }
     
     virtual void ref(result_observer_multiple_inheritance_helper_tag_t) const override {

--- a/include/eventkit/promise/global_functions/detail/whenAll-inl.h
+++ b/include/eventkit/promise/global_functions/detail/whenAll-inl.h
@@ -11,14 +11,14 @@ namespace global_functions {
 namespace detail {
 
 template <size_t Idx, typename Cr, typename LastPr>
-void addCoreAsHandlerToPromisesAt(const ek::common::intrusive_ptr<Cr>& pCore, LastPr&& lastPr) {
+void addCoreAsHandlerToPromisesAt(const ek::common::IntrusivePtr<Cr>& pCore, LastPr&& lastPr) {
     lastPr.pipe(ek::promise::detail::make_function_observer<typename LastPr::Value, typename LastPr::Error>([pCore](const auto& result){
         pCore->template onResultAt<Idx>(result);
     }));
 }
 
 template <size_t Idx, typename Cr, typename PrAtIndex, typename ...RestPrs>
-void addCoreAsHandlerToPromisesAt(const ek::common::intrusive_ptr<Cr>& pCore, PrAtIndex&& promiseAtIndex, RestPrs&& ...restPromises) {
+void addCoreAsHandlerToPromisesAt(const ek::common::IntrusivePtr<Cr>& pCore, PrAtIndex&& promiseAtIndex, RestPrs&& ...restPromises) {
     promiseAtIndex.pipe(ek::promise::detail::make_function_observer<typename PrAtIndex::Value, typename PrAtIndex::Error>([pCore](const auto& result){
         pCore->template onResultAt<Idx>(result);
     }));
@@ -26,7 +26,7 @@ void addCoreAsHandlerToPromisesAt(const ek::common::intrusive_ptr<Cr>& pCore, Pr
 }
 
 template <typename Cr, typename ...Prs>
-void addCoreAsHandlerToPromises(const ek::common::intrusive_ptr<Cr>& pCore, Prs&& ...promises) {
+void addCoreAsHandlerToPromises(const ek::common::IntrusivePtr<Cr>& pCore, Prs&& ...promises) {
     addCoreAsHandlerToPromisesAt<0>(pCore, std::forward<Prs>(promises)...);
 }
 

--- a/source/dispatch/DispatchQueue.cpp
+++ b/source/dispatch/DispatchQueue.cpp
@@ -7,7 +7,7 @@
 namespace ek {
 namespace dispatch {
 
-void DispatchQueue::dispatchItemAsync(const ek::common::intrusive_ptr<DispatchItem>& pTask) {
+void DispatchQueue::dispatchItemAsync(const ek::common::IntrusivePtr<DispatchItem>& pTask) {
     std::lock_guard<std::mutex> lock(m_mutex);
     m_queue.push(pTask);
     m_pRunLoop->signal();
@@ -16,7 +16,7 @@ void DispatchQueue::dispatchItemAsync(const ek::common::intrusive_ptr<DispatchIt
 void DispatchQueue::fire() {
     bool isEmpty = false;
     do {
-        ek::common::intrusive_ptr<DispatchItem> item = nullptr;
+        ek::common::IntrusivePtr<DispatchItem> item = nullptr;
         {
             std::lock_guard<std::mutex> lock(m_mutex);
 

--- a/source/dispatch/RunLoop.cpp
+++ b/source/dispatch/RunLoop.cpp
@@ -16,7 +16,7 @@ void RunLoop::run() {
             auto pos = m_dispatchQueues.begin();
             auto end = m_dispatchQueues.end();
             for (; pos != end; ++pos) {
-                const ek::common::intrusive_ptr<DispatchQueue>& pTaskQueue = *pos;
+                const ek::common::IntrusivePtr<DispatchQueue>& pTaskQueue = *pos;
                 pTaskQueue->fire();
             }
         }
@@ -29,7 +29,7 @@ void RunLoop::run() {
     } while (!isFinished);
 }
 
-void RunLoop::addDispatchQueue(const ek::common::intrusive_ptr<DispatchQueue>& pQueue) {
+void RunLoop::addDispatchQueue(const ek::common::IntrusivePtr<DispatchQueue>& pQueue) {
     if (pQueue == nullptr) {
         return;
     }


### PR DESCRIPTION
- `intrusive_ptr`を他のクラスに合わせて`IntrusivePtr`にリネームします
- `RefCountObject`を`intrusive_ptr`の関係性がわかるように`IntrusiveObject`にリネームします