### PR TITLE
Allocatorを導入する

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ find_package(Threads)
 include_directories(include)
 
 set(LIBRARY_SOURCE_FILES
+    include/eventkit/common/Allocator.h
+    include/eventkit/common/SystemAllocator.h
     include/eventkit/common/IntrusivePtr.h
     include/eventkit/common/IntrusiveObject.h
     include/eventkit/dispatch/detail/Semaphore.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCE_FILES
     include/eventkit/common/SystemAllocator.h
     include/eventkit/common/IntrusivePtr.h
     include/eventkit/common/IntrusiveObject.h
+    source/common/Allocator.cpp
     include/eventkit/dispatch/detail/Semaphore.h
     include/eventkit/dispatch/DispatchQueue.h
     include/eventkit/dispatch/detail/DispatchQueue-inl.h

--- a/include/eventkit/common/Allocator.h
+++ b/include/eventkit/common/Allocator.h
@@ -1,0 +1,51 @@
+//
+// Created by Tsujita Masahiko on 2020/08/23.
+//
+
+#ifndef EVENTKIT_ALLOCATOR_H
+#define EVENTKIT_ALLOCATOR_H
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+
+namespace ek {
+namespace common {
+
+class Allocator {
+public:
+    virtual ~Allocator() = default;
+
+    virtual void* allocate(std::size_t size) = 0;
+
+    virtual void deallocate(void* p) = 0;
+
+    template <typename T, typename ...Args>
+    void construct(T* p, Args&& ...args) {
+        new(p) T(std::forward<Args>(args)...);
+    }
+
+    template <typename T>
+    void destruct(T* p) {
+        p->~T();
+    }
+
+    template <typename T, typename ...Args>
+    T* create(Args&& ...args) {
+        T* p = static_cast<T*>(allocate(sizeof(T)));
+        construct(p, std::forward<Args>(args)...);
+        return p;
+    }
+
+    template <typename T>
+    void destroy(T* p) {
+        destruct(p);
+        deallocate(static_cast<void*>(p));
+    }
+
+};
+
+}
+}
+
+#endif //EVENTKIT_ALLOCATOR_H

--- a/include/eventkit/common/Allocator.h
+++ b/include/eventkit/common/Allocator.h
@@ -45,6 +45,8 @@ public:
 
 };
 
+Allocator* GetDefaultAllocator();
+
 }
 }
 

--- a/include/eventkit/common/IntrusivePtr.h
+++ b/include/eventkit/common/IntrusivePtr.h
@@ -6,6 +6,7 @@
 #define EVENTKIT_INTRUSIVEPTR_H
 
 #include <utility>
+#include <eventkit/common/Allocator.h>
 
 namespace ek {
 namespace common {
@@ -199,8 +200,8 @@ IntrusivePtr<T> dynamic_pointer_cast(const IntrusivePtr<U>& p) {
 #endif
 
 template <typename T, typename ...Args>
-IntrusivePtr<T> make_intrusive(Args&& ...args) {
-    return IntrusivePtr<T>(new T (std::forward<Args>(args)...), false);
+IntrusivePtr<T> make_intrusive(Allocator* pA, Args&& ...args) {
+    return IntrusivePtr<T>(pA->create<T>(std::forward<Args>(args)...), false);
 }
 
 }

--- a/include/eventkit/common/SystemAllocator.h
+++ b/include/eventkit/common/SystemAllocator.h
@@ -1,0 +1,33 @@
+//
+// Created by Tsujita Masahiko on 2020/08/24.
+//
+
+#ifndef EVENTKIT_SYSTEMALLOCATOR_H
+#define EVENTKIT_SYSTEMALLOCATOR_H
+
+#include <eventkit/common/Allocator.h>
+
+namespace ek {
+namespace common {
+
+class SystemAllocator : public Allocator {
+public:
+
+    SystemAllocator() = default;
+
+    virtual ~SystemAllocator() = default;
+
+    virtual void* allocate(std::size_t size) override {
+        return ::operator new(size);
+    }
+
+    virtual void deallocate(void* p) override {
+        ::operator delete(p);
+    }
+
+};
+
+}
+}
+
+#endif //EVENTKIT_SYSTEMALLOCATOR_H

--- a/include/eventkit/dispatch/DispatchQueue.h
+++ b/include/eventkit/dispatch/DispatchQueue.h
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <list>
 #include <queue>
+#include <eventkit/common/Allocator.h>
 #include <eventkit/dispatch/RunLoop.h>
 #include <eventkit/common/IntrusiveObject.h>
 
@@ -16,6 +17,8 @@ namespace dispatch {
 
 class DispatchItem : public ek::common::IntrusiveObject {
 public:
+    explicit DispatchItem(ek::common::Allocator* pA) : ek::common::IntrusiveObject(pA) {}
+
     virtual ~DispatchItem() = default;
 
     virtual void run() = 0;
@@ -27,7 +30,7 @@ class DispatchFunctionItem : public DispatchItem {
 public:
 
     template <typename F>
-    explicit DispatchFunctionItem(F&& function);
+    explicit DispatchFunctionItem(ek::common::Allocator* pA, F&& function);
 
     ~DispatchFunctionItem() override = default;
 
@@ -43,8 +46,13 @@ public:
 
     friend class RunLoop;
 
+    explicit DispatchQueue(ek::common::Allocator* pA)
+        : ek::common::IntrusiveObject(pA)
+        , m_pRunLoop(nullptr) {
+    }
+
     template <typename F>
-    void dispatchAsync(F&& function);
+    void dispatchAsync(ek::common::Allocator* pA, F&& function);
 
 private:
 

--- a/include/eventkit/dispatch/detail/DispatchQueue-inl.h
+++ b/include/eventkit/dispatch/detail/DispatchQueue-inl.h
@@ -5,13 +5,16 @@
 #ifndef EVENTKIT_DISPATCHQUEUE_INL_H
 #define EVENTKIT_DISPATCHQUEUE_INL_H
 
+#include <eventkit/common/Allocator.h>
+
 namespace ek {
 namespace dispatch {
 
 template <typename Function>
 template <typename F>
-DispatchFunctionItem<Function>::DispatchFunctionItem(F&& function)
-    : m_function(std::forward<F>(function)) {
+DispatchFunctionItem<Function>::DispatchFunctionItem(ek::common::Allocator* pA, F&& function)
+    : DispatchItem(pA)
+    , m_function(std::forward<F>(function)) {
 }
 
 template <typename Function>
@@ -20,8 +23,8 @@ void DispatchFunctionItem<Function>::run() {
 }
 
 template <typename F>
-void DispatchQueue::dispatchAsync(F&& function) {
-    dispatchItemAsync(ek::common::make_intrusive<DispatchFunctionItem<std::decay_t<F>>>(std::forward<F>(function)));
+void DispatchQueue::dispatchAsync(ek::common::Allocator* pA, F&& function) {
+    dispatchItemAsync(ek::common::make_intrusive<DispatchFunctionItem<std::decay_t<F>>>(pA, pA, std::forward<F>(function)));
 }
 
 }

--- a/include/eventkit/promise/ResultObserver.h
+++ b/include/eventkit/promise/ResultObserver.h
@@ -19,9 +19,9 @@ public:
 
     virtual void onResult(const Result <T, E>& result) = 0;
     
-    virtual void ref() const = 0;
+    virtual void ref() = 0;
     
-    virtual void unref() const = 0;
+    virtual void unref() = 0;
 
 };
 

--- a/include/eventkit/promise/detail/PromiseCore.h
+++ b/include/eventkit/promise/detail/PromiseCore.h
@@ -16,11 +16,14 @@ namespace promise {
 namespace detail {
 
 template <typename T, typename E>
-class PromiseCore : public ResultObserver<T, E>, public ek::common::IntrusiveObject {
+class PromiseCore : public ek::common::IntrusiveObject, public ResultObserver<T, E> {
 public:
     using Handler = ResultObserver<T, E>;
 
-    PromiseCore() : m_isResolved(false) {}
+    explicit PromiseCore(ek::common::Allocator* pA)
+        : ek::common::IntrusiveObject(pA)
+        , m_isResolved(false) {
+    }
 
     virtual void onResult(const Result<T, E>& result) override {
         std::unique_lock<std::mutex> lock(m_mutex);
@@ -45,11 +48,11 @@ public:
         }
     }
     
-    virtual void ref() const override {
+    virtual void ref() override {
         ek::common::IntrusiveObject::ref();
     }
     
-    virtual void unref() const override {
+    virtual void unref() override {
         ek::common::IntrusiveObject::unref();
     }
 

--- a/include/eventkit/promise/detail/RecoverTransformationCore.h
+++ b/include/eventkit/promise/detail/RecoverTransformationCore.h
@@ -19,8 +19,9 @@ class RecoverTransformationCore :
     public ResultObserverMultipleInheritanceHelper<T, E> {
 public:
     template <typename Tr>
-    explicit RecoverTransformationCore(Tr&& transformation)
-        : m_transformation(std::forward<Tr>(transformation))
+    explicit RecoverTransformationCore(ek::common::Allocator* pA, Tr&& transformation)
+        : PromiseCore<T, F>(pA)
+        , m_transformation(std::forward<Tr>(transformation))
     {
     }
 
@@ -42,11 +43,11 @@ public:
         return ek::common::IntrusivePtr<ResultObserver<T, E>>(static_cast<ResultObserverMultipleInheritanceHelper<T, E>*>(this));
     }
     
-    virtual void ref(result_observer_multiple_inheritance_helper_tag_t) const override {
+    virtual void ref(result_observer_multiple_inheritance_helper_tag_t) override {
         PromiseCore<T, F>::ref();
     }
     
-    virtual void unref(result_observer_multiple_inheritance_helper_tag_t) const override {
+    virtual void unref(result_observer_multiple_inheritance_helper_tag_t) override {
         PromiseCore<T, F>::unref();
     }
 

--- a/include/eventkit/promise/detail/ResultObserver-inl.h
+++ b/include/eventkit/promise/detail/ResultObserver-inl.h
@@ -10,11 +10,12 @@ namespace promise {
 namespace detail {
 
 template <typename T, typename E, typename Function>
-class FunctionResultObserver : public ResultObserver<T, E>, public ek::common::IntrusiveObject {
+class FunctionResultObserver : public ek::common::IntrusiveObject, public ResultObserver<T, E> {
 public:
     template <typename F>
-    explicit FunctionResultObserver(F&& function)
-        : m_function(std::forward<F>(function)) {
+    explicit FunctionResultObserver(ek::common::Allocator* pA, F&& function)
+        : ek::common::IntrusiveObject(pA)
+        , m_function(std::forward<F>(function)) {
     }
     
     virtual ~FunctionResultObserver() override = default;
@@ -23,11 +24,11 @@ public:
         m_function(result);
     }
     
-    virtual void ref() const override {
+    virtual void ref() override {
         ek::common::IntrusiveObject::ref();
     }
     
-    virtual void unref() const override {
+    virtual void unref() override {
         ek::common::IntrusiveObject::unref();
     }
 
@@ -37,8 +38,8 @@ private:
 };
 
 template <typename T, typename E, typename Function>
-auto make_function_observer(Function&& function) -> ek::common::IntrusivePtr<ResultObserver < T, E>> {
-    return ek::common::make_intrusive<FunctionResultObserver<T, E, std::decay_t<Function>>>(std::forward<Function>(function));
+auto make_function_observer(ek::common::Allocator* pA, Function&& function) -> ek::common::IntrusivePtr<ResultObserver < T, E>> {
+    return ek::common::make_intrusive<FunctionResultObserver<T, E, std::decay_t<Function>>>(pA, pA, std::forward<Function>(function));
 }
 
 }

--- a/include/eventkit/promise/detail/ResultObserverMultipleInheritanceHelper.h
+++ b/include/eventkit/promise/detail/ResultObserverMultipleInheritanceHelper.h
@@ -29,19 +29,19 @@ public:
         onResult(result_observer_multiple_inheritance_helper_tag, result);
     }
     
-    virtual void ref() const override {
+    virtual void ref() override {
         ref(result_observer_multiple_inheritance_helper_tag);
     }
     
-    virtual void unref() const override {
+    virtual void unref() override {
         unref(result_observer_multiple_inheritance_helper_tag);
     }
     
     virtual void onResult(result_observer_multiple_inheritance_helper_tag_t, const Result<T, E>& result) = 0;
     
-    virtual void ref(result_observer_multiple_inheritance_helper_tag_t) const = 0;
+    virtual void ref(result_observer_multiple_inheritance_helper_tag_t) = 0;
     
-    virtual void unref(result_observer_multiple_inheritance_helper_tag_t) const = 0;
+    virtual void unref(result_observer_multiple_inheritance_helper_tag_t) = 0;
     
 };
 

--- a/include/eventkit/promise/detail/ThenTransformationCore.h
+++ b/include/eventkit/promise/detail/ThenTransformationCore.h
@@ -19,8 +19,9 @@ class ThenTransformationCore :
     public ResultObserverMultipleInheritanceHelper<T, E> {
 public:
     template <typename Tr>
-    explicit ThenTransformationCore(Tr&& transformation)
-        : m_transformation(std::forward<Tr>(transformation))
+    explicit ThenTransformationCore(ek::common::Allocator* pA, Tr&& transformation)
+        : PromiseCore<U, E>(pA)
+        , m_transformation(std::forward<Tr>(transformation))
     {
     }
 
@@ -42,11 +43,11 @@ public:
         return ek::common::IntrusivePtr<ResultObserver<T, E>>(static_cast<ResultObserverMultipleInheritanceHelper<T, E>*>(this));
     }
     
-    virtual void ref(result_observer_multiple_inheritance_helper_tag_t) const override {
+    virtual void ref(result_observer_multiple_inheritance_helper_tag_t) override {
         PromiseCore<U, E>::ref();
     }
     
-    virtual void unref(result_observer_multiple_inheritance_helper_tag_t) const override {
+    virtual void unref(result_observer_multiple_inheritance_helper_tag_t) override {
         PromiseCore<U, E>::unref();
     }
 

--- a/include/eventkit/promise/detail/WhenAllTransformationCore.h
+++ b/include/eventkit/promise/detail/WhenAllTransformationCore.h
@@ -24,6 +24,12 @@ public:
     using Error = error_of_prmises_t<Prs...>;
     using Super = PromiseCore<Values, Error>;
     using Result = ek::promise::Result<Values, Error>;
+
+    explicit WhenAllTransformationCore(ek::common::Allocator* pA)
+        : Super(pA)
+        , m_values()
+        , m_fulfilledPromiseFlags() {
+    }
     
     template <size_t Index>
     void onResultAt(const std::tuple_element_t<Index, Results>& result) {
@@ -52,8 +58,8 @@ public:
     using Super = PromiseCore<Values, Error>;
     using Results = Result<std::vector<T>, E>;
 
-    explicit DynamicWhenAllTransformationCore(size_t size)
-        : Super()
+    explicit DynamicWhenAllTransformationCore(ek::common::Allocator* pA, size_t size)
+        : Super(pA)
         , m_values(size)
         , m_fulfilledFlags(size, false) {
     }

--- a/sample/dispatch_sample/main.cpp
+++ b/sample/dispatch_sample/main.cpp
@@ -4,29 +4,32 @@
 
 #include <iostream>
 #include <thread>
+#include <eventkit/common/SystemAllocator.h>
 #include <eventkit/dispatch/RunLoop.h>
 #include <eventkit/dispatch/DispatchQueue.h>
 
+ek::common::SystemAllocator g_allocator;
+
 int main(int argc, const char* argv[]) {
     ek::dispatch::RunLoop mainLoop;
-    auto pMainQueue = ek::common::make_intrusive<ek::dispatch::DispatchQueue>();
+    auto pMainQueue = ek::common::make_intrusive<ek::dispatch::DispatchQueue>(&g_allocator, &g_allocator);
     mainLoop.addDispatchQueue(pMainQueue);
 
     ek::dispatch::RunLoop bgLoop;
-    auto pBgQueue = ek::common::make_intrusive<ek::dispatch::DispatchQueue>();
+    auto pBgQueue = ek::common::make_intrusive<ek::dispatch::DispatchQueue>(&g_allocator, &g_allocator);
     bgLoop.addDispatchQueue(pBgQueue);
 
-    pMainQueue->dispatchAsync([] {
+    pMainQueue->dispatchAsync(&g_allocator, [] {
         printf("a task running on main thread.\n");
     });
 
-    pBgQueue->dispatchAsync([] {
+    pBgQueue->dispatchAsync(&g_allocator, [] {
         printf("a task running on background thread.\n");
     });
 
-    pBgQueue->dispatchAsync([&] {
+    pBgQueue->dispatchAsync(&g_allocator, [&] {
         printf("dispatching a task to main thread from background thread.\n");
-        pMainQueue->dispatchAsync([] {
+        pMainQueue->dispatchAsync(&g_allocator, [] {
             printf("a task running on main thread dispatched from background thread.\n");
         });
     });

--- a/sample/dispatch_sample/main.cpp
+++ b/sample/dispatch_sample/main.cpp
@@ -8,28 +8,26 @@
 #include <eventkit/dispatch/RunLoop.h>
 #include <eventkit/dispatch/DispatchQueue.h>
 
-ek::common::SystemAllocator g_allocator;
-
 int main(int argc, const char* argv[]) {
     ek::dispatch::RunLoop mainLoop;
-    auto pMainQueue = ek::common::make_intrusive<ek::dispatch::DispatchQueue>(&g_allocator, &g_allocator);
+    auto pMainQueue = ek::common::make_intrusive<ek::dispatch::DispatchQueue>(ek::common::GetDefaultAllocator(), ek::common::GetDefaultAllocator());
     mainLoop.addDispatchQueue(pMainQueue);
 
     ek::dispatch::RunLoop bgLoop;
-    auto pBgQueue = ek::common::make_intrusive<ek::dispatch::DispatchQueue>(&g_allocator, &g_allocator);
+    auto pBgQueue = ek::common::make_intrusive<ek::dispatch::DispatchQueue>(ek::common::GetDefaultAllocator(), ek::common::GetDefaultAllocator());
     bgLoop.addDispatchQueue(pBgQueue);
 
-    pMainQueue->dispatchAsync(&g_allocator, [] {
+    pMainQueue->dispatchAsync(ek::common::GetDefaultAllocator(), [] {
         printf("a task running on main thread.\n");
     });
 
-    pBgQueue->dispatchAsync(&g_allocator, [] {
+    pBgQueue->dispatchAsync(ek::common::GetDefaultAllocator(), [] {
         printf("a task running on background thread.\n");
     });
 
-    pBgQueue->dispatchAsync(&g_allocator, [&] {
+    pBgQueue->dispatchAsync(ek::common::GetDefaultAllocator(), [&] {
         printf("dispatching a task to main thread from background thread.\n");
-        pMainQueue->dispatchAsync(&g_allocator, [] {
+        pMainQueue->dispatchAsync(ek::common::GetDefaultAllocator(), [] {
             printf("a task running on main thread dispatched from background thread.\n");
         });
     });

--- a/sample/promise_sample/main.cpp
+++ b/sample/promise_sample/main.cpp
@@ -17,15 +17,13 @@ std::atomic_bool g_isDone { false };
 struct Unit {};
 struct NoError {};
 
-ek::common::SystemAllocator g_allocator;
-
 int main(int argc, const char* argv[]) {
     using Promise = ek::promise::Promise<std::string, int>;
     using namespace std::chrono_literals;
     using namespace ek::promise::global_functions;
     
-    whenAll(&g_allocator, {
-        Promise(&g_allocator, [argc, argv](const ek::promise::Resolver<std::string, int>& resolver){
+    whenAll(ek::common::GetDefaultAllocator(), {
+        Promise(ek::common::GetDefaultAllocator(), [argc, argv](const ek::promise::Resolver<std::string, int>& resolver){
             std::thread thread([resolver, argc, argv]{
                 LOG("processing...");
                 std::this_thread::sleep_for(5s);
@@ -41,8 +39,8 @@ int main(int argc, const char* argv[]) {
             });
             thread.detach();
         }),
-        Promise::value(&g_allocator, ", "),
-        Promise(&g_allocator, [argc, argv](const ek::promise::Resolver<std::string, int>& resolver){
+        Promise::value(ek::common::GetDefaultAllocator(), ", "),
+        Promise(ek::common::GetDefaultAllocator(), [argc, argv](const ek::promise::Resolver<std::string, int>& resolver){
             std::thread thread([resolver, argc, argv]{
                 LOG("processing...");
                 std::this_thread::sleep_for(3s);
@@ -58,24 +56,24 @@ int main(int argc, const char* argv[]) {
             });
             thread.detach();
         }),
-        Promise::value(&g_allocator, "!")
-    }).then(&g_allocator, [](const std::vector<std::string>& texts){
+        Promise::value(ek::common::GetDefaultAllocator(), "!")
+    }).then(ek::common::GetDefaultAllocator(), [](const std::vector<std::string>& texts){
         LOG("concatenating...");
         std::string concatenated = texts[0] + texts[1] + texts[2] + texts[3];
-        return ek::promise::Promise<std::string, int>::value(&g_allocator, concatenated);
-    }).then(&g_allocator, [](const std::string& text){
+        return ek::promise::Promise<std::string, int>::value(ek::common::GetDefaultAllocator(), concatenated);
+    }).then(ek::common::GetDefaultAllocator(), [](const std::string& text){
         LOG("quoting...");
         std::stringstream ss;
         ss << "\"" << text << "\"";
         std::string quoted = ss.str();
-        return ek::promise::Promise<std::string, int>::value(&g_allocator, quoted);
-    }).then(&g_allocator, [](const std::string& text){
+        return ek::promise::Promise<std::string, int>::value(ek::common::GetDefaultAllocator(), quoted);
+    }).then(ek::common::GetDefaultAllocator(), [](const std::string& text){
         LOG("succeeded: ", text);
-        return ek::promise::Promise<Unit, int>::value(&g_allocator);
-    }).recover(&g_allocator, [](int error){
+        return ek::promise::Promise<Unit, int>::value(ek::common::GetDefaultAllocator());
+    }).recover(ek::common::GetDefaultAllocator(), [](int error){
         LOG("failed: ", error);
-        return ek::promise::Promise<Unit, NoError>::value(&g_allocator);
-    }).done(&g_allocator, [](const ek::promise::Result<Unit, NoError>& result){
+        return ek::promise::Promise<Unit, NoError>::value(ek::common::GetDefaultAllocator());
+    }).done(ek::common::GetDefaultAllocator(), [](const ek::promise::Result<Unit, NoError>& result){
         LOG("done. ");
         g_isDone = true;
     });

--- a/source/common/Allocator.cpp
+++ b/source/common/Allocator.cpp
@@ -1,0 +1,18 @@
+//
+// Created by Tsujita Masahiko on 2020/08/30.
+//
+
+#include <eventkit/common/Allocator.h>
+#include <eventkit/common/SystemAllocator.h>
+
+namespace ek {
+namespace common {
+
+SystemAllocator g_systemAllocator;
+
+Allocator* GetDefaultAllocator() {
+    return &g_systemAllocator;
+}
+
+}
+}

--- a/test/RunLoopTest.cpp
+++ b/test/RunLoopTest.cpp
@@ -11,8 +11,6 @@
 
 using namespace std::chrono_literals;
 
-ek::common::SystemAllocator g_allocator;
-
 SCENARIO("a run loop", "[run_loop]") {
 
     GIVEN("a run loop without any event sources") {
@@ -32,7 +30,7 @@ SCENARIO("a run loop", "[run_loop]") {
         }
 
         WHEN("a event source added to the run loop") {
-            auto pDispatchQueue = ek::common::make_intrusive<ek::dispatch::DispatchQueue>(&g_allocator, &g_allocator);
+            auto pDispatchQueue = ek::common::make_intrusive<ek::dispatch::DispatchQueue>(ek::common::GetDefaultAllocator(), ek::common::GetDefaultAllocator());
             pRunLoop->addDispatchQueue(pDispatchQueue);
 
             WHEN("the run loop starts running on a thread") {

--- a/test/RunLoopTest.cpp
+++ b/test/RunLoopTest.cpp
@@ -5,10 +5,13 @@
 #include <thread>
 #include <catch2/catch.hpp>
 #include "TestUtils.h"
+#include <eventkit/common/SystemAllocator.h>
 #include <eventkit/dispatch/RunLoop.h>
 #include <eventkit/dispatch/DispatchQueue.h>
 
 using namespace std::chrono_literals;
+
+ek::common::SystemAllocator g_allocator;
 
 SCENARIO("a run loop", "[run_loop]") {
 
@@ -29,7 +32,7 @@ SCENARIO("a run loop", "[run_loop]") {
         }
 
         WHEN("a event source added to the run loop") {
-            auto pDispatchQueue = ek::common::make_intrusive<ek::dispatch::DispatchQueue>();
+            auto pDispatchQueue = ek::common::make_intrusive<ek::dispatch::DispatchQueue>(&g_allocator, &g_allocator);
             pRunLoop->addDispatchQueue(pDispatchQueue);
 
             WHEN("the run loop starts running on a thread") {


### PR DESCRIPTION
- アロケータ基底クラスとして`Allocator`を追加します
    - `Allocator`は独自のインターフェースを持ち、標準ライブラリのアロケータと互換性がありません。
    - STLと異なり、多態アロケータのみをサポートします。これはC++17で追加された`std::polymorphic_allocator<T>`に類似していますが、テンプレートではなく、また`std::memory_resource`のような型を持たず直接継承されます。
    - デフォルト実装として`SystemAllocator`が追加されます。
- アロケータの追加に合わせてAPIや内部実装の変更を行います
    - 全ての動的確保を伴う関数呼び出し、または動的関数呼び出しを行うクラスについてアロケータの指定が必要になります
    - アロケータは明示的に指定されるべきというポリシーなので、アロケータは常に指定が必要で、暗黙的に指定されません。
- 現在以下の制約があります：
    - アロケータにより確保されたメモリの先頭アドレスと、破棄されるアドレスは同じである必要があります。
        - 例えば、多重継承を行う場合は基底クラスと派生クラスのアドレスが異なる場合があるので注意が必要です。
        - `IntrusiveObject`から派生する一部のクラスは多重継承の問題があるため修正されました。