### PR TITLE
Improve promise members

### DIFF
--- a/include/eventkit/promise/Promise.h
+++ b/include/eventkit/promise/Promise.h
@@ -58,7 +58,7 @@ public:
     }
 
     template <typename Handler>
-    auto then(ek::common::Allocator* pA, Handler&& handler) -> Promise<typename std::result_of_t<Handler(T)>::Value, E> {
+    auto then(ek::common::Allocator* pA, Handler&& handler) const -> Promise<typename std::result_of_t<Handler(T)>::Value, E> {
         using U = typename std::result_of_t<Handler(T)>::Value;
         auto pCore = ek::common::make_intrusive<ek::promise::detail::ThenTransformationCore<T, E, U, std::decay_t<Handler>>>(pA, pA, std::forward<std::decay_t<Handler>>(handler));
         done(pCore->asHandler());
@@ -66,7 +66,7 @@ public:
     }
 
     template <typename Handler>
-    auto recover(ek::common::Allocator* pA, Handler&& handler) -> Promise<T, typename std::result_of_t<Handler(E)>::Error> {
+    auto recover(ek::common::Allocator* pA, Handler&& handler) const -> Promise<T, typename std::result_of_t<Handler(E)>::Error> {
         using F = typename std::result_of_t<Handler(E)>::Error;
         auto pCore = ek::common::make_intrusive<ek::promise::detail::RecoverTransformationCore<T, E, F, std::decay_t<Handler>>>(pA, pA, std::forward<std::decay_t<Handler>>(handler));
         done(pCore->asHandler());
@@ -74,7 +74,7 @@ public:
     }
 
     template <typename Handler>
-    Promise done(ek::common::Allocator* pA, Handler&& handler) {
+    Promise done(ek::common::Allocator* pA, Handler&& handler) const {
         done(ek::promise::detail::make_function_observer<T, E>(pA, std::forward<Handler>(handler)));
         return *this;
     }

--- a/include/eventkit/promise/Promise.h
+++ b/include/eventkit/promise/Promise.h
@@ -57,10 +57,6 @@ public:
         return Promise(pCore);
     }
 
-    void done(const ek::common::IntrusivePtr<ResultObserver<T, E>>& handler) const {
-        m_pCore->addHandler(handler);
-    }
-
     template <typename Handler>
     auto then(ek::common::Allocator* pA, Handler&& handler) -> Promise<typename std::result_of_t<Handler(T)>::Value, E> {
         using U = typename std::result_of_t<Handler(T)>::Value;
@@ -81,6 +77,10 @@ public:
     Promise& done(ek::common::Allocator* pA, Handler&& handler) {
         done(ek::promise::detail::make_function_observer<T, E>(pA, std::forward<Handler>(handler)));
         return *this;
+    }
+
+    void done(const ek::common::IntrusivePtr<ResultObserver<T, E>>& handler) const {
+        m_pCore->addHandler(handler);
     }
 
 private:

--- a/include/eventkit/promise/Promise.h
+++ b/include/eventkit/promise/Promise.h
@@ -57,7 +57,7 @@ public:
         return Promise(pCore);
     }
 
-    void pipe(const ek::common::IntrusivePtr<ResultObserver<T, E>>& handler) const {
+    void done(const ek::common::IntrusivePtr<ResultObserver<T, E>>& handler) const {
         m_pCore->addHandler(handler);
     }
 
@@ -65,7 +65,7 @@ public:
     auto then(ek::common::Allocator* pA, Handler&& handler) -> Promise<typename std::result_of_t<Handler(T)>::Value, E> {
         using U = typename std::result_of_t<Handler(T)>::Value;
         auto pCore = ek::common::make_intrusive<ek::promise::detail::ThenTransformationCore<T, E, U, std::decay_t<Handler>>>(pA, pA, std::forward<std::decay_t<Handler>>(handler));
-        pipe(pCore->asHandler());
+        done(pCore->asHandler());
         return ek::promise::detail::make_promise(pCore->asCore());
     }
 
@@ -73,13 +73,13 @@ public:
     auto recover(ek::common::Allocator* pA, Handler&& handler) -> Promise<T, typename std::result_of_t<Handler(E)>::Error> {
         using F = typename std::result_of_t<Handler(E)>::Error;
         auto pCore = ek::common::make_intrusive<ek::promise::detail::RecoverTransformationCore<T, E, F, std::decay_t<Handler>>>(pA, pA, std::forward<std::decay_t<Handler>>(handler));
-        pipe(pCore->asHandler());
+        done(pCore->asHandler());
         return ek::promise::detail::make_promise(pCore->asCore());
     }
 
     template <typename Handler>
     Promise& done(ek::common::Allocator* pA, Handler&& handler) {
-        pipe(ek::promise::detail::make_function_observer<T, E>(pA, std::forward<Handler>(handler)));
+        done(ek::promise::detail::make_function_observer<T, E>(pA, std::forward<Handler>(handler)));
         return *this;
     }
 

--- a/include/eventkit/promise/Promise.h
+++ b/include/eventkit/promise/Promise.h
@@ -74,13 +74,14 @@ public:
     }
 
     template <typename Handler>
-    Promise& done(ek::common::Allocator* pA, Handler&& handler) {
+    Promise done(ek::common::Allocator* pA, Handler&& handler) {
         done(ek::promise::detail::make_function_observer<T, E>(pA, std::forward<Handler>(handler)));
         return *this;
     }
 
-    void done(const ek::common::IntrusivePtr<ResultObserver<T, E>>& handler) const {
+    Promise done(const ek::common::IntrusivePtr<ResultObserver<T, E>>& handler) const {
         m_pCore->addHandler(handler);
+        return *this;
     }
 
 private:

--- a/include/eventkit/promise/detail/RecoverTransformationCore.h
+++ b/include/eventkit/promise/detail/RecoverTransformationCore.h
@@ -29,7 +29,7 @@ public:
 
     virtual void onResult (result_observer_multiple_inheritance_helper_tag_t, const Result<T, E>& result) override {
         if (result.getType() == ResultType::failed) {
-            m_transformation(result.getError()).pipe(asCore());
+            m_transformation(result.getError()).done(asCore());
         } else {
             PromiseCore<T, F>::onResult(Result<T, F>::succeeded(result.getValue()));
         }

--- a/include/eventkit/promise/detail/ThenTransformationCore.h
+++ b/include/eventkit/promise/detail/ThenTransformationCore.h
@@ -29,7 +29,7 @@ public:
 
     virtual void onResult(result_observer_multiple_inheritance_helper_tag_t, const Result<T, E>& result) override {
         if (result.getType() == ResultType::succeeded) {
-            m_transformation(result.getValue()).pipe(asCore());
+            m_transformation(result.getValue()).done(asCore());
         } else {
             PromiseCore<U, E>::onResult(Result<U, E>::failed(result.getError()));
         }

--- a/include/eventkit/promise/global_functions/detail/whenAll-inl.h
+++ b/include/eventkit/promise/global_functions/detail/whenAll-inl.h
@@ -12,14 +12,14 @@ namespace detail {
 
 template <size_t Idx, typename Cr, typename LastPr>
 void addCoreAsHandlerToPromisesAt(const ek::common::IntrusivePtr<Cr>& pCore, LastPr&& lastPr) {
-    lastPr.pipe(ek::promise::detail::make_function_observer<typename LastPr::Value, typename LastPr::Error>([pCore](const auto& result){
+    lastPr.done(ek::promise::detail::make_function_observer<typename LastPr::Value, typename LastPr::Error>([pCore](const auto& result){
         pCore->template onResultAt<Idx>(result);
     }));
 }
 
 template <size_t Idx, typename Cr, typename PrAtIndex, typename ...RestPrs>
 void addCoreAsHandlerToPromisesAt(const ek::common::IntrusivePtr<Cr>& pCore, PrAtIndex&& promiseAtIndex, RestPrs&& ...restPromises) {
-    promiseAtIndex.pipe(ek::promise::detail::make_function_observer<typename PrAtIndex::Value, typename PrAtIndex::Error>([pCore](const auto& result){
+    promiseAtIndex.done(ek::promise::detail::make_function_observer<typename PrAtIndex::Value, typename PrAtIndex::Error>([pCore](const auto& result){
         pCore->template onResultAt<Idx>(result);
     }));
     addCoreAsHandlerToPromisesAt<Idx + 1>(pCore, std::forward<RestPrs>(restPromises)...);

--- a/include/eventkit/promise/global_functions/whenAll.h
+++ b/include/eventkit/promise/global_functions/whenAll.h
@@ -38,7 +38,7 @@ auto whenAll(ek::common::Allocator* pA, InputIt begin, InputIt end) {
     auto itr = begin;
     for (; itr != end; ++itr, ++idx) {
         const auto& promise = *itr;
-        promise.pipe(ek::promise::detail::make_function_observer<T, E>(pA, [pCore, idx](const auto& result){
+        promise.done(ek::promise::detail::make_function_observer<T, E>(pA, [pCore, idx](const auto& result){
             pCore->onResultAt(result, idx);
         }));
     }


### PR DESCRIPTION
- `Promise::pipe()` を `Promise::done()`にリネームし、自分のコピーを返すように変更します
- `Promise`の`const`のついていないメンバ関数を`const`にします