### PR TITLE
Fulfiller, Rejecterを削除する

### DIFF
--- a/include/eventkit/promise/Resolver.h
+++ b/include/eventkit/promise/Resolver.h
@@ -24,12 +24,6 @@ namespace ek {
 namespace promise {
 
 template <typename T, typename E>
-class Fulfiller;
-
-template <typename T, typename E>
-class Rejecter;
-
-template <typename T, typename E>
 class Resolver final {
 private:
     using Core = detail::PromiseCore<T, E>;
@@ -50,54 +44,6 @@ public:
     
     void operator () (const Result<T, E>& result) const {
         m_pCore->onResult(result);
-    }
-
-    explicit operator Fulfiller<T, E> () const {
-        return Fulfiller<T, E>(m_pCore);
-    }
-
-    explicit operator Rejecter<T, E> () const {
-        return Rejecter<T, E>(m_pCore);
-    }
-
-private:
-    ek::common::IntrusivePtr<Core> m_pCore;
-
-};
-
-template <typename T, typename E>
-class Fulfiller final {
-private:
-    using Core = detail::PromiseCore<T, E>;
-
-public:
-
-    explicit Fulfiller(const ek::common::IntrusivePtr<Core>& pCore)
-        : m_pCore(pCore) {
-    }
-
-    void operator () (const T& value) const {
-        m_pCore->onResult(Result<T, E>::succeeded(value));
-    }
-
-private:
-    ek::common::IntrusivePtr<Core> m_pCore;
-
-};
-
-template <typename T, typename E>
-class Rejecter final {
-private:
-    using Core = detail::PromiseCore<T, E>;
-
-public:
-
-    explicit Rejecter(const ek::common::IntrusivePtr<Core>& pCore)
-        : m_pCore(pCore) {
-    }
-
-    void operator () (const E& error) const {
-        m_pCore->onResult(Result<T, E>::failed(error));
     }
 
 private:


### PR DESCRIPTION
- `Promise`を解決するコンテキストでは、多くの場合、値とエラーの両方を送出し得るので、片方の機能だけを持つ`Fulfiller`と`Rejecter`は廃止されました。代わりに`Resolver`を使用してください。
