### PR TITLE
Separate ResultHandler.h and -inl.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ set(LIBRARY_SOURCE_FILES
     include/eventkit/promise/Resolver.h
     include/eventkit/promise/ResultHandler.h
     include/eventkit/promise/detail/ResultHandler-inl.h
+    include/eventkit/promise/detail/FunctionResultHandler.h
+    include/eventkit/promise/detail/FunctionResultHandler-inl.h
     include/eventkit/promise/detail/PromiseCore.h
     include/eventkit/promise/detail/ResultHandlerMultipleInheritanceHelper.h
     include/eventkit/promise/detail/ThenTransformationCore.h

--- a/include/eventkit/promise/ResultHandler.h
+++ b/include/eventkit/promise/ResultHandler.h
@@ -25,14 +25,10 @@ public:
 };
 
 template <typename T, typename E>
-void intrusive_ptr_ref(ResultHandler<T, E>* p) {
-    p->ref();
-}
+void intrusive_ptr_ref(ResultHandler<T, E>* p);
 
 template <typename T, typename E>
-void intrusive_ptr_unref(ResultHandler<T, E>* p) {
-    p->unref();
-}
+void intrusive_ptr_unref(ResultHandler<T, E>* p);
 
 }
 }

--- a/include/eventkit/promise/detail/FunctionResultHandler-inl.h
+++ b/include/eventkit/promise/detail/FunctionResultHandler-inl.h
@@ -1,0 +1,45 @@
+//
+// Created by Tsujita Masahiko on 2020/09/04.
+//
+
+#ifndef EVENTKIT_FUNCTIONRESULTHANDLER_INL_H
+#define EVENTKIT_FUNCTIONRESULTHANDLER_INL_H
+
+#include <eventkit/promise/detail/FunctionResultHandler.h>
+
+namespace ek {
+namespace promise {
+namespace detail{
+
+template <typename T, typename E, typename Function>
+template <typename F>
+FunctionResultHandler<T, E, Function>::FunctionResultHandler(ek::common::Allocator* pA, F&& function)
+    : ek::common::IntrusiveObject(pA)
+    , m_function(std::forward<F>(function)) {
+}
+
+template <typename T, typename E, typename Function>
+void FunctionResultHandler<T, E, Function>::onResult(const Result <T, E>& result) {
+    m_function(result);
+}
+
+template <typename T, typename E, typename Function>
+void FunctionResultHandler<T, E, Function>::ref() {
+    ek::common::IntrusiveObject::ref();
+}
+
+template <typename T, typename E, typename Function>
+void FunctionResultHandler<T, E, Function>::unref() {
+    ek::common::IntrusiveObject::unref();
+}
+
+template <typename T, typename E, typename Function>
+auto make_function_observer(ek::common::Allocator* pA, Function&& function) -> ek::common::IntrusivePtr<ResultHandler < T, E>> {
+return ek::common::make_intrusive<FunctionResultHandler<T, E, std::decay_t<Function>>>(pA, pA, std::forward<Function>(function));
+}
+
+}
+}
+}
+
+#endif //EVENTKIT_FUNCTIONRESULTHANDLER_INL_H

--- a/include/eventkit/promise/detail/FunctionResultHandler.h
+++ b/include/eventkit/promise/detail/FunctionResultHandler.h
@@ -1,0 +1,41 @@
+//
+// Created by Tsujita Masahiko on 2020/09/04.
+//
+
+#ifndef EVENTKIT_FUNCTIONRESULTHANDLER_H
+#define EVENTKIT_FUNCTIONRESULTHANDLER_H
+
+#include <eventkit/common/Allocator.h>
+#include <eventkit/common/IntrusiveObject.h>
+#include <eventkit/promise/ResultHandler.h>
+
+namespace ek {
+namespace promise {
+namespace detail {
+
+template <typename T, typename E, typename Function>
+class FunctionResultHandler : public ek::common::IntrusiveObject, public ResultHandler<T, E> {
+public:
+    template <typename F>
+    explicit FunctionResultHandler(ek::common::Allocator* pA, F&& function);
+
+    virtual ~FunctionResultHandler() override = default;
+
+    virtual void onResult(const Result<T, E>& result) override;
+
+    virtual void ref() override;
+
+    virtual void unref() override;
+
+private:
+    Function m_function;
+
+};
+
+}
+}
+}
+
+#include <eventkit/promise/detail/FunctionResultHandler-inl.h>
+
+#endif //EVENTKIT_FUNCTIONRESULTHANDLER_H

--- a/include/eventkit/promise/detail/Promise-inl.h
+++ b/include/eventkit/promise/detail/Promise-inl.h
@@ -7,6 +7,7 @@
 
 #include <eventkit/promise/Promise.h>
 #include <eventkit/promise/detail/make_promise.h>
+#include <eventkit/promise/detail/FunctionResultHandler.h>
 #include <eventkit/promise/Resolver.h>
 #include <eventkit/promise/detail/ThenTransformationCore.h>
 #include <eventkit/promise/detail/RecoverTransformationCore.h>

--- a/include/eventkit/promise/detail/ResultHandler-inl.h
+++ b/include/eventkit/promise/detail/ResultHandler-inl.h
@@ -7,42 +7,17 @@
 
 namespace ek {
 namespace promise {
-namespace detail {
 
-template <typename T, typename E, typename Function>
-class FunctionResultHandler : public ek::common::IntrusiveObject, public ResultHandler<T, E> {
-public:
-    template <typename F>
-    explicit FunctionResultHandler(ek::common::Allocator* pA, F&& function)
-        : ek::common::IntrusiveObject(pA)
-        , m_function(std::forward<F>(function)) {
-    }
-    
-    virtual ~FunctionResultHandler() override = default;
-    
-    virtual void onResult(const Result <T, E>& result) override {
-        m_function(result);
-    }
-    
-    virtual void ref() override {
-        ek::common::IntrusiveObject::ref();
-    }
-    
-    virtual void unref() override {
-        ek::common::IntrusiveObject::unref();
-    }
-
-private:
-    Function m_function;
-    
-};
-
-template <typename T, typename E, typename Function>
-auto make_function_observer(ek::common::Allocator* pA, Function&& function) -> ek::common::IntrusivePtr<ResultHandler < T, E>> {
-    return ek::common::make_intrusive<FunctionResultHandler<T, E, std::decay_t<Function>>>(pA, pA, std::forward<Function>(function));
+template <typename T, typename E>
+void intrusive_ptr_ref(ResultHandler<T, E>* p) {
+    p->ref();
 }
 
+template <typename T, typename E>
+void intrusive_ptr_unref(ResultHandler<T, E>* p) {
+    p->unref();
 }
+
 }
 }
 


### PR DESCRIPTION
- ResultHandler.h の インライン実装を -inl.h に分離します
- ResultHandler-inl.h は既にあり、`FunctionResultHandler`が置かれているので、`FunctionResultHandler`は別途 .h と -inl.h に分離します