### PR TITLE
Separate interface and implementation (`ek::common` namespace)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCE_FILES
     include/eventkit/common/detail/Allocator-inl.h
     include/eventkit/common/SystemAllocator.h
     include/eventkit/common/IntrusivePtr.h
+    include/eventkit/common/detail/IntrusivePtr-inl.h
     include/eventkit/common/IntrusiveObject.h
     include/eventkit/common/IntrusiveObjectMixin.h
     source/common/Allocator.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ include_directories(include)
 
 set(LIBRARY_SOURCE_FILES
     include/eventkit/common/Allocator.h
+    include/eventkit/common/detail/Allocator-inl.h
     include/eventkit/common/SystemAllocator.h
     include/eventkit/common/IntrusivePtr.h
     include/eventkit/common/IntrusiveObject.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBRARY_SOURCE_FILES
     include/eventkit/common/IntrusiveObject.h
     include/eventkit/common/IntrusiveObjectMixin.h
     source/common/Allocator.cpp
+    source/common/SystemAllocator.cpp
     include/eventkit/dispatch/detail/Semaphore.h
     include/eventkit/dispatch/DispatchQueue.h
     include/eventkit/dispatch/detail/DispatchQueue-inl.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBRARY_SOURCE_FILES
     include/eventkit/common/IntrusiveObjectMixin.h
     source/common/Allocator.cpp
     source/common/SystemAllocator.cpp
+    source/common/IntrusiveObjectMixin.cpp
     include/eventkit/dispatch/detail/Semaphore.h
     include/eventkit/dispatch/DispatchQueue.h
     include/eventkit/dispatch/detail/DispatchQueue-inl.h

--- a/include/eventkit/common/Allocator.h
+++ b/include/eventkit/common/Allocator.h
@@ -6,8 +6,6 @@
 #define EVENTKIT_ALLOCATOR_H
 
 #include <cstddef>
-#include <memory>
-#include <utility>
 
 namespace ek {
 namespace common {
@@ -21,27 +19,16 @@ public:
     virtual void deallocate(void* p) = 0;
 
     template <typename T, typename ...Args>
-    void construct(T* p, Args&& ...args) {
-        new(p) T(std::forward<Args>(args)...);
-    }
+    void construct(T* p, Args&& ...args);
 
     template <typename T>
-    void destruct(T* p) {
-        p->~T();
-    }
+    void destruct(T* p);
 
     template <typename T, typename ...Args>
-    T* create(Args&& ...args) {
-        T* p = static_cast<T*>(allocate(sizeof(T)));
-        construct(p, std::forward<Args>(args)...);
-        return p;
-    }
+    T* create(Args&& ...args);
 
     template <typename T>
-    void destroy(T* p) {
-        destruct(p);
-        deallocate(static_cast<void*>(p));
-    }
+    void destroy(T* p);
 
 };
 
@@ -49,5 +36,7 @@ Allocator* getDefaultAllocator();
 
 }
 }
+
+#include <eventkit/common/detail/Allocator-inl.h>
 
 #endif //EVENTKIT_ALLOCATOR_H

--- a/include/eventkit/common/IntrusiveObjectMixin.h
+++ b/include/eventkit/common/IntrusiveObjectMixin.h
@@ -5,41 +5,29 @@
 #ifndef EVENTKIT_INTRUSIVEOBJECTMIXIN_H
 #define EVENTKIT_INTRUSIVEOBJECTMIXIN_H
 
-#include <cassert>
 #include <atomic>
-#include <eventkit/common/Allocator.h>
 
 namespace ek {
 namespace common {
+
+class Allocator;
 
 class IntrusiveObjectMixin final {
 public:
 
     using Deleter = void (*)(IntrusiveObjectMixin* pMixin, void* pContext);
 
-    explicit IntrusiveObjectMixin(Deleter pDeleter, void* pContext)
-        : m_pDeleter(pDeleter)
-        , m_pContext(pContext)
-        , m_refCount(1) {
-    }
+    explicit IntrusiveObjectMixin(Deleter pDeleter, void* pContext);
 
     IntrusiveObjectMixin(const IntrusiveObjectMixin&) = delete;
+
     IntrusiveObjectMixin& operator = (const IntrusiveObjectMixin&) = delete;
 
-    ~IntrusiveObjectMixin() {
-        assert(m_refCount == 0);
-    }
+    ~IntrusiveObjectMixin();
 
-    void ref() {
-        std::atomic_fetch_add_explicit(&m_refCount, 1u, std::memory_order_relaxed);
-    }
+    void ref();
 
-    void unref() {
-        if (std::atomic_fetch_sub_explicit(&m_refCount, 1u, std::memory_order_release) == 1) {
-            std::atomic_thread_fence(std::memory_order_acquire);
-            m_pDeleter(this, m_pContext);
-        }
-    }
+    void unref();
 
 private:
     Deleter m_pDeleter;

--- a/include/eventkit/common/IntrusivePtr.h
+++ b/include/eventkit/common/IntrusivePtr.h
@@ -5,11 +5,10 @@
 #ifndef EVENTKIT_INTRUSIVEPTR_H
 #define EVENTKIT_INTRUSIVEPTR_H
 
-#include <utility>
-#include <eventkit/common/Allocator.h>
-
 namespace ek {
 namespace common {
+
+class Allocator;
 
 template <typename T>
 class IntrusivePtr {
@@ -17,110 +16,43 @@ public:
     
     using element_type = T;
     
-    IntrusivePtr()
-        : m_p(nullptr) {
-    }
+    IntrusivePtr();
     
     template <typename U>
-    explicit IntrusivePtr(U* p, bool add_ref = true)
-        : m_p(p) {
-        if (p != nullptr && add_ref) {
-            intrusive_ptr_ref(p);
-        }
-    }
+    explicit IntrusivePtr(U* p, bool add_ref = true);
+
+    IntrusivePtr(std::nullptr_t);
     
-    IntrusivePtr(std::nullptr_t)
-        : m_p(nullptr) {
-    }
-    
-    IntrusivePtr(const IntrusivePtr& rhs)
-        : m_p(rhs.m_p) {
-        if (m_p != nullptr) {
-            intrusive_ptr_ref(m_p);
-        }
-    }
+    IntrusivePtr(const IntrusivePtr& rhs);
     
     template<class U>
-    IntrusivePtr(const IntrusivePtr<U>& rhs)
-        : m_p(rhs.m_p) {
-        if (m_p != nullptr) {
-            intrusive_ptr_ref(m_p);
-        }
-    }
+    IntrusivePtr(const IntrusivePtr<U>& rhs);
     
-    IntrusivePtr(IntrusivePtr&& rhs)
-        : m_p(rhs.m_p) {
-        rhs.m_p = nullptr;
-    }
+    IntrusivePtr(IntrusivePtr&& rhs);
     
     template<class U>
     friend class IntrusivePtr;
     
     template<class U>
-    IntrusivePtr(IntrusivePtr<U>&& rhs)
-        : m_p(rhs.m_p) {
-        rhs.m_p = nullptr;
-    }
+    IntrusivePtr(IntrusivePtr<U>&& rhs);
     
-    IntrusivePtr& operator = (const IntrusivePtr& rhs) {
-        if (m_p != nullptr) {
-            intrusive_ptr_unref(m_p);
-        }
-        m_p = rhs.m_p;
-        if (m_p != nullptr) {
-            intrusive_ptr_ref(m_p);
-        }
-        return *this;
-    }
+    IntrusivePtr& operator = (const IntrusivePtr& rhs);
     
     template <typename U>
-    IntrusivePtr& operator = (const IntrusivePtr<U>& rhs) {
-        if (m_p != nullptr) {
-            intrusive_ptr_unref(m_p);
-        }
-        m_p = rhs.m_p;
-        if (m_p != nullptr) {
-            intrusive_ptr_ref(m_p);
-        }
-        return *this;
-    }
+    IntrusivePtr& operator = (const IntrusivePtr<U>& rhs);
     
-    IntrusivePtr& operator = (IntrusivePtr&& another) noexcept {
-        if (m_p != nullptr) {
-            intrusive_ptr_unref(m_p);
-        }
-        m_p = another.m_p;
-        another.m_p = nullptr;
-        return *this;
-    }
+    IntrusivePtr& operator = (IntrusivePtr&& another) noexcept;
     
     template <typename U>
-    IntrusivePtr& operator = (IntrusivePtr<U>&& another) noexcept {
-        if (m_p != nullptr) {
-            intrusive_ptr_unref(m_p);
-        }
-        m_p = another.m_p;
-        another.m_p = nullptr;
-        return *this;
-    }
+    IntrusivePtr& operator = (IntrusivePtr<U>&& another) noexcept;
     
-    ~IntrusivePtr() {
-        if (m_p != nullptr) {
-            intrusive_ptr_unref(m_p);
-        }
-    }
+    ~IntrusivePtr();
     
-    T* get() const {
-        return m_p;
-    }
+    T* get() const;
     
-    T& operator * () const {
-        return *m_p;
-    }
+    T& operator * () const;
     
-    T* operator -> () const {
-        return m_p;
-    }
+    T* operator -> () const;
 
 private:
     T* m_p;
@@ -128,83 +60,55 @@ private:
 };
 
 template<class T, class U>
-inline bool operator == (const IntrusivePtr<T>& a, const IntrusivePtr<U>& b) {
-    return a.get() == b.get();
-}
+inline bool operator == (const IntrusivePtr<T>& a, const IntrusivePtr<U>& b);
 
 template<class T, class U>
-inline bool operator != (const IntrusivePtr<T>& a, const IntrusivePtr<U>& b) {
-    return a.get() != b.get();
-}
+inline bool operator != (const IntrusivePtr<T>& a, const IntrusivePtr<U>& b);
 
 template<class T, class U>
-inline bool operator == (const IntrusivePtr<T>& a, U* b) {
-    return a.get() == b;
-}
+inline bool operator == (const IntrusivePtr<T>& a, U* b);
 
 template<class T, class U>
-inline bool operator != (const IntrusivePtr<T>& a, U * b) {
-    return a.get() != b;
-}
+inline bool operator != (const IntrusivePtr<T>& a, U * b);
 
 template<class T, class U>
-inline bool operator == (T* a, const IntrusivePtr<U>& b) {
-    return a == b.get();
-}
+inline bool operator == (T* a, const IntrusivePtr<U>& b);
 
 template<class T, class U>
-inline bool operator != (T * a, const IntrusivePtr<U>& b) {
-    return a != b.get();
-}
+inline bool operator != (T * a, const IntrusivePtr<U>& b);
 
 template<class T>
-inline bool operator == (const IntrusivePtr<T>& p, std::nullptr_t) {
-    return p.get() == nullptr;
-}
+inline bool operator == (const IntrusivePtr<T>& p, std::nullptr_t);
 
 template<class T>
-inline bool operator == (std::nullptr_t, const IntrusivePtr<T>& p) {
-    return p.get() == nullptr;
-}
+inline bool operator == (std::nullptr_t, const IntrusivePtr<T>& p);
 
 template<class T>
-inline bool operator != (const IntrusivePtr<T>& p, std::nullptr_t) {
-    return p.get() != nullptr;
-}
+inline bool operator != (const IntrusivePtr<T>& p, std::nullptr_t);
 
 template<class T>
-inline bool operator != (std::nullptr_t, const IntrusivePtr<T>& p) {
-    return p.get() != nullptr;
-}
+inline bool operator != (std::nullptr_t, const IntrusivePtr<T>& p);
 
 template<class T>
-T * get_pointer(const IntrusivePtr<T>& p) {
-    return p.get();
-}
+T * get_pointer(const IntrusivePtr<T>& p);
 
 template<class T, class U>
-IntrusivePtr<T> static_pointer_cast(const IntrusivePtr<U>& p) {
-    return static_cast<T*>(p.get());
-}
+IntrusivePtr<T> static_pointer_cast(const IntrusivePtr<U>& p);
 
 template<class T, class U>
-IntrusivePtr<T> const_pointer_cast(const IntrusivePtr<U>& p) {
-    return const_cast<T*>(p.get());
-}
+IntrusivePtr<T> const_pointer_cast(const IntrusivePtr<U>& p);
 
 #if defined(EVENTKIT_ENABLE_RTTI)
 template<class T, class U>
-IntrusivePtr<T> dynamic_pointer_cast(const IntrusivePtr<U>& p) {
-    return dynamic_cast<T*>(p.get());
-}
+IntrusivePtr<T> dynamic_pointer_cast(const IntrusivePtr<U>& p);
 #endif
 
 template <typename T, typename ...Args>
-IntrusivePtr<T> make_intrusive(Allocator* pA, Args&& ...args) {
-    return IntrusivePtr<T>(pA->create<T>(std::forward<Args>(args)...), false);
-}
+IntrusivePtr<T> make_intrusive(Allocator* pA, Args&& ...args);
 
 }
 }
+
+#include <eventkit/common/detail/IntrusivePtr-inl.h>
 
 #endif //EVENTKIT_INTRUSIVEPTR_H

--- a/include/eventkit/common/SystemAllocator.h
+++ b/include/eventkit/common/SystemAllocator.h
@@ -17,13 +17,9 @@ public:
 
     virtual ~SystemAllocator() = default;
 
-    virtual void* allocate(std::size_t size) override {
-        return ::operator new(size);
-    }
+    virtual void* allocate(std::size_t size) override;
 
-    virtual void deallocate(void* p) override {
-        ::operator delete(p);
-    }
+    virtual void deallocate(void* p) override;
 
 };
 

--- a/include/eventkit/common/detail/Allocator-inl.h
+++ b/include/eventkit/common/detail/Allocator-inl.h
@@ -1,0 +1,41 @@
+//
+// Created by Tsujita Masahiko on 2020/09/12.
+//
+
+#ifndef EVENTKIT_ALLOCATOR_INL_H
+#define EVENTKIT_ALLOCATOR_INL_H
+
+#include <eventkit/common/Allocator.h>
+#include <memory>
+#include <utility>
+
+namespace ek {
+namespace common {
+
+template <typename T, typename... Args>
+void Allocator::construct(T* p, Args&& ... args) {
+    new(p) T(std::forward<Args>(args)...);
+}
+
+template <typename T>
+void Allocator::destruct(T* p) {
+    p->~T();
+}
+
+template <typename T, typename... Args>
+T* Allocator::create(Args&& ... args) {
+    T* p = static_cast<T*>(allocate(sizeof(T)));
+    construct(p, std::forward<Args>(args)...);
+    return p;
+}
+
+template <typename T>
+void Allocator::destroy(T* p) {
+    destruct(p);
+    deallocate(static_cast<void*>(p));
+}
+
+}
+}
+
+#endif //EVENTKIT_ALLOCATOR_INL_H

--- a/include/eventkit/common/detail/IntrusivePtr-inl.h
+++ b/include/eventkit/common/detail/IntrusivePtr-inl.h
@@ -1,0 +1,212 @@
+//
+// Created by Tsujita Masahiko on 2020/09/12.
+//
+
+#ifndef EVENTKIT_INTRUSIVEPTR_INL_H
+#define EVENTKIT_INTRUSIVEPTR_INL_H
+
+#include <eventkit/common/IntrusivePtr.h>
+#include <eventkit/common/Allocator.h>
+#include <utility>
+
+namespace ek {
+namespace common {
+
+template <typename T>
+IntrusivePtr<T>::IntrusivePtr()
+    : m_p(nullptr) {
+}
+
+template <typename T>
+template <typename U>
+IntrusivePtr<T>::IntrusivePtr(U* p, bool add_ref)
+    : m_p(p) {
+    if (p != nullptr && add_ref) {
+        intrusive_ptr_ref(p);
+    }
+}
+
+template <typename T>
+IntrusivePtr<T>::IntrusivePtr(std::nullptr_t)
+    : m_p(nullptr) {
+}
+
+template <typename T>
+IntrusivePtr<T>::IntrusivePtr(const IntrusivePtr& rhs)
+    : m_p(rhs.m_p) {
+    if (m_p != nullptr) {
+        intrusive_ptr_ref(m_p);
+    }
+}
+
+template <typename T>
+IntrusivePtr<T>::IntrusivePtr(IntrusivePtr&& rhs)
+    : m_p(rhs.m_p) {
+    rhs.m_p = nullptr;
+}
+
+template <typename T>
+template <class U>
+IntrusivePtr<T>::IntrusivePtr(const IntrusivePtr<U>& rhs)
+    : m_p(rhs.m_p) {
+    if (m_p != nullptr) {
+        intrusive_ptr_ref(m_p);
+    }
+}
+
+template <typename T>
+template <class U>
+IntrusivePtr<T>::IntrusivePtr(IntrusivePtr<U>&& rhs)
+    : m_p(rhs.m_p) {
+    rhs.m_p = nullptr;
+}
+
+template <typename T>
+template <typename U>
+IntrusivePtr<T>& IntrusivePtr<T>::operator =(const IntrusivePtr<U>& rhs) {
+    if (m_p != nullptr) {
+        intrusive_ptr_unref(m_p);
+    }
+    m_p = rhs.m_p;
+    if (m_p != nullptr) {
+        intrusive_ptr_ref(m_p);
+    }
+    return *this;
+}
+
+template <typename T>
+template <typename U>
+IntrusivePtr<T>& IntrusivePtr<T>::operator =(IntrusivePtr<U>&& another) noexcept {
+    if (m_p != nullptr) {
+        intrusive_ptr_unref(m_p);
+    }
+    m_p = another.m_p;
+    another.m_p = nullptr;
+    return *this;
+}
+
+template <typename T>
+IntrusivePtr<T>::~IntrusivePtr() {
+    if (m_p != nullptr) {
+        intrusive_ptr_unref(m_p);
+    }
+}
+
+template <typename T>
+T* IntrusivePtr<T>::get() const {
+    return m_p;
+}
+
+template <typename T>
+T& IntrusivePtr<T>::operator *() const {
+    return *m_p;
+}
+
+template <typename T>
+T* IntrusivePtr<T>::operator ->() const {
+    return m_p;
+}
+
+template <typename T>
+IntrusivePtr<T>& IntrusivePtr<T>::operator =(IntrusivePtr&& another) noexcept {
+    if (m_p != nullptr) {
+        intrusive_ptr_unref(m_p);
+    }
+    m_p = another.m_p;
+    another.m_p = nullptr;
+    return *this;
+}
+
+template <typename T>
+IntrusivePtr<T>& IntrusivePtr<T>::operator =(const IntrusivePtr& rhs) {
+    if (m_p != nullptr) {
+        intrusive_ptr_unref(m_p);
+    }
+    m_p = rhs.m_p;
+    if (m_p != nullptr) {
+        intrusive_ptr_ref(m_p);
+    }
+    return *this;
+}
+
+template <class T, class U>
+bool operator ==(const IntrusivePtr<T>& a, const IntrusivePtr<U>& b) {
+    return a.get() == b.get();
+}
+
+template <class T, class U>
+bool operator !=(const IntrusivePtr <T>& a, const IntrusivePtr <U>& b) {
+    return a.get() != b.get();
+}
+
+template <class T, class U>
+bool operator ==(const IntrusivePtr <T>& a, U* b) {
+    return a.get() == b;
+}
+
+template <class T, class U>
+bool operator !=(const IntrusivePtr <T>& a, U* b) {
+    return a.get() != b;
+}
+
+template <class T, class U>
+bool operator ==(T* a, const IntrusivePtr <U>& b) {
+    return a == b.get();
+}
+
+template <class T, class U>
+bool operator !=(T* a, const IntrusivePtr <U>& b) {
+    return a != b.get();
+}
+
+template <class T>
+bool operator ==(const IntrusivePtr <T>& p, std::nullptr_t) {
+    return p.get() == nullptr;
+}
+
+template <class T>
+bool operator ==(std::nullptr_t, const IntrusivePtr <T>& p) {
+    return p.get() == nullptr;
+}
+
+template <class T>
+bool operator !=(const IntrusivePtr <T>& p, std::nullptr_t) {
+    return p.get() != nullptr;
+}
+
+template <class T>
+bool operator !=(std::nullptr_t, const IntrusivePtr <T>& p) {
+    return p.get() != nullptr;
+}
+
+template <class T>
+T* get_pointer(const IntrusivePtr <T>& p) {
+    return p.get();
+}
+
+template <class T, class U>
+IntrusivePtr <T> static_pointer_cast(const IntrusivePtr <U>& p) {
+    return static_cast<T*>(p.get());
+}
+
+template <class T, class U>
+IntrusivePtr <T> const_pointer_cast(const IntrusivePtr <U>& p) {
+    return const_cast<T*>(p.get());
+}
+
+#if defined(EVENTKIT_ENABLE_RTTI)
+template<class T, class U>
+IntrusivePtr<T> dynamic_pointer_cast(const IntrusivePtr<U>& p) {
+    return dynamic_cast<T*>(p.get());
+}
+#endif
+
+template <typename T, typename... Args>
+IntrusivePtr <T> make_intrusive(Allocator* pA, Args&& ... args) {
+    return IntrusivePtr<T>(pA->create<T>(std::forward<Args>(args)...), false);
+}
+
+}
+}
+
+#endif //EVENTKIT_INTRUSIVEPTR_INL_H

--- a/source/common/IntrusiveObjectMixin.cpp
+++ b/source/common/IntrusiveObjectMixin.cpp
@@ -1,0 +1,33 @@
+//
+// Created by Tsujita Masahiko on 2020/09/12.
+//
+
+#include <eventkit/common/IntrusiveObjectMixin.h>
+#include <cassert>
+
+namespace ek {
+namespace common {
+
+IntrusiveObjectMixin::IntrusiveObjectMixin(IntrusiveObjectMixin::Deleter pDeleter, void* pContext)
+    : m_pDeleter(pDeleter)
+    , m_pContext(pContext)
+    , m_refCount(1) {
+}
+
+IntrusiveObjectMixin::~IntrusiveObjectMixin() {
+    assert(m_refCount == 0);
+}
+
+void IntrusiveObjectMixin::ref() {
+    std::atomic_fetch_add_explicit(&m_refCount, 1u, std::memory_order_relaxed);
+}
+
+void IntrusiveObjectMixin::unref() {
+    if (std::atomic_fetch_sub_explicit(&m_refCount, 1u, std::memory_order_release) == 1) {
+        std::atomic_thread_fence(std::memory_order_acquire);
+        m_pDeleter(this, m_pContext);
+    }
+}
+
+}
+}

--- a/source/common/SystemAllocator.cpp
+++ b/source/common/SystemAllocator.cpp
@@ -1,0 +1,19 @@
+//
+// Created by Tsujita Masahiko on 2020/09/12.
+//
+
+#include <eventkit/common/SystemAllocator.h>
+
+namespace ek {
+namespace common {
+
+void* SystemAllocator::allocate(std::size_t size) {
+    return ::operator new(size);
+}
+
+void SystemAllocator::deallocate(void* p) {
+    ::operator delete(p);
+}
+
+}
+}


### PR DESCRIPTION
- ヘッダとソースファイル(及びinlineファイル)を分けます。 #8 
- とりあえず`ek::common` に適用します。