### PR TITLE
アロケータスタックを導入

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,9 @@ set(LIBRARY_SOURCE_FILES
     include/eventkit/promise/detail/WhenAllTransformationPromiseCore.h
     include/eventkit/promise/global_functions/detail/whenAll-inl.h
     include/eventkit/promise/global_functions/whenAll.h
+    include/eventkit/common/AllocatorStack.h
+    include/eventkit/common/AllocatorScope.h
+    source/common/AllocatorStack.cpp
 )
 
 add_library(eventkit ${LIBRARY_SOURCE_FILES})

--- a/include/eventkit/common/AllocatorScope.h
+++ b/include/eventkit/common/AllocatorScope.h
@@ -1,0 +1,42 @@
+//
+// Created by Tsujita Masahiko on 2021/03/10.
+//
+
+#ifndef EVENTKIT_ALLOCATORSCOPE_H
+#define EVENTKIT_ALLOCATORSCOPE_H
+
+#include <eventkit/common/AllocatorStack.h>
+#include <type_traits>
+
+namespace ek {
+namespace common {
+
+class AllocatorScope final {
+public:
+
+    explicit AllocatorScope(Allocator* pAllocator) {
+        pushAllocator(pAllocator);
+    }
+
+    ~AllocatorScope() {
+        popAllocator();
+    }
+
+    AllocatorScope(const AllocatorScope&) = delete;
+
+    AllocatorScope& operator = (const AllocatorScope&) = delete;
+
+};
+
+template <typename Block>
+std::result_of_t<Block()> withAllocator(Allocator* pAllocator, Block&& block) {
+    AllocatorScope scopedAllocation(pAllocator);
+    return block();
+}
+
+}
+}
+
+#define EK_USING_ALLOCATOR(pA) ek::common::AllocatorScope __ek_scoped_allocator_using ## __LINE__ { pA }
+
+#endif //EVENTKIT_ALLOCATORSCOPE_H

--- a/include/eventkit/common/AllocatorScope.h
+++ b/include/eventkit/common/AllocatorScope.h
@@ -30,13 +30,13 @@ public:
 
 template <typename Block>
 std::result_of_t<Block()> withAllocator(Allocator* pAllocator, Block&& block) {
-    AllocatorScope scopedAllocation(pAllocator);
+    AllocatorScope allocatorScope(pAllocator);
     return block();
 }
 
 }
 }
 
-#define EK_USING_ALLOCATOR(pA) ek::common::AllocatorScope __ek_scoped_allocator_using ## __LINE__ { pA }
+#define EK_USING_ALLOCATOR(pA) ek::common::AllocatorScope __EK_USING_ALLOCATOR_allocatorScope ## __LINE__ { pA }
 
 #endif //EVENTKIT_ALLOCATORSCOPE_H

--- a/include/eventkit/common/AllocatorStack.h
+++ b/include/eventkit/common/AllocatorStack.h
@@ -1,0 +1,26 @@
+//
+// Created by Tsujita Masahiko on 2021/03/08.
+//
+
+#ifndef EVENTKIT_ALLOCATORSTACK_H
+#define EVENTKIT_ALLOCATORSTACK_H
+
+namespace ek {
+namespace common {
+class Allocator;
+}
+}
+
+namespace ek {
+namespace common {
+
+void pushAllocator(Allocator* pAllocator);
+
+void popAllocator();
+
+Allocator* getCurrentAllocator();
+
+}
+}
+
+#endif //EVENTKIT_ALLOCATORSTACK_H

--- a/include/eventkit/promise/Promise.h
+++ b/include/eventkit/promise/Promise.h
@@ -33,24 +33,24 @@ public:
     using Error = E;
 
     template <typename StartHandler>
-    explicit Promise(ek::common::Allocator* pA, const StartHandler& startHandler);
+    explicit Promise(const StartHandler& startHandler);
 
     template <typename ...Args>
-    static Promise value(ek::common::Allocator* pA, Args&& ...args);
+    static Promise value(Args&& ...args);
 
     template <typename ...Args>
-    static Promise error(ek::common::Allocator* pA, Args&& ...args);
+    static Promise error(Args&& ...args);
 
     template <typename Handler>
-    Promise<typename std::result_of_t<Handler(T)>::Value, E> then(ek::common::Allocator* pA, Handler&& handler) const;
+    Promise<typename std::result_of_t<Handler(T)>::Value, E> then(Handler&& handler) const;
 
     template <typename Handler>
-    Promise<T, typename std::result_of_t<Handler(E)>::Error> recover(ek::common::Allocator* pA, Handler&& handler) const;
+    Promise<T, typename std::result_of_t<Handler(E)>::Error> recover(Handler&& handler) const;
 
     template <typename Handler>
-    Promise done(ek::common::Allocator* pA, Handler&& handler) const;
+    Promise done(Handler&& handler) const;
 
-    Promise done(const ek::common::IntrusivePtr<ResultHandler<T, E>>& handler) const;
+    Promise done(const ek::common::IntrusivePtr<ResultHandler<T, E>>& handler, void*) const;
 
 private:
     using Core = detail::PromiseCore<T, E>;
@@ -58,7 +58,7 @@ private:
     template <typename U, typename F>
     friend ek::promise::Promise<U, F> detail::make_promise(const ek::common::IntrusivePtr<ek::promise::detail::PromiseCore<U, F>>& pCore);
 
-    explicit Promise(const ek::common::IntrusivePtr<Core>& pCore);
+    explicit Promise(const ek::common::IntrusivePtr<Core>& pCore, void*);
 
 private:
     ek::common::IntrusivePtr<Core> m_pCore;

--- a/include/eventkit/promise/detail/BasicPromiseCore.h
+++ b/include/eventkit/promise/detail/BasicPromiseCore.h
@@ -17,7 +17,7 @@ public:
     using Handler = ResultHandler<T, E>;
 
     explicit BasicPromiseCore(ek::common::Allocator* pA)
-        : PromiseCore<T, E>()
+        : PromiseCore<T, E>(pA)
         , m_pA(pA)
         , m_intrusiveObjectMixin(deleteCallback, this) {
     }

--- a/include/eventkit/promise/detail/RecoverTransformationPromiseCore.h
+++ b/include/eventkit/promise/detail/RecoverTransformationPromiseCore.h
@@ -92,7 +92,7 @@ template <typename T, typename E, typename F, typename Handler>
 void RecoverTransformationPromiseCore<T, E, F, Handler>::onSrcResultCallback(const Result<T, E>& result, void* pContext) {
     auto* pThis = static_cast<RecoverTransformationPromiseCore*>(pContext);
     if (result.getType() == ResultType::failed) {
-        pThis->m_transformation(result.getError()).done(pThis->asDstResultHandler());
+        pThis->m_transformation(result.getError()).done(pThis->asDstResultHandler(), nullptr);
     } else {
         pThis->resolve(Result<T, F>::succeeded(result.getValue()));
     }

--- a/include/eventkit/promise/detail/RecoverTransformationPromiseCore.h
+++ b/include/eventkit/promise/detail/RecoverTransformationPromiseCore.h
@@ -53,7 +53,7 @@ private:
 template <typename T, typename E, typename F, typename Handler>
 template <typename Tr>
 RecoverTransformationPromiseCore<T, E, F, Handler>::RecoverTransformationPromiseCore(ek::common::Allocator* pA, Tr&& transformation)
-    : PromiseCore<T, F>()
+    : PromiseCore<T, F>(pA)
     , m_transformation(std::forward<Tr>(transformation))
     , m_pA(pA)
     , m_intrusiveObjectMixin(deleteCallback, this)

--- a/include/eventkit/promise/detail/ThenTransformationPromiseCore.h
+++ b/include/eventkit/promise/detail/ThenTransformationPromiseCore.h
@@ -92,7 +92,7 @@ template <typename T, typename E, typename U, typename Handler>
 void ThenTransformationPromiseCore<T, E, U, Handler>::onSrcResultCallback(const Result<T, E>& result, void* pContext) {
     auto* pThis = static_cast<ThenTransformationPromiseCore*>(pContext);
     if (result.getType() == ResultType::succeeded) {
-        pThis->m_transformation(result.getValue()).done(pThis->asDstResultHandler());
+        pThis->m_transformation(result.getValue()).done(pThis->asDstResultHandler(), nullptr);
     } else {
         pThis->resolve(Result<U, E>::failed(result.getError()));
     }

--- a/include/eventkit/promise/detail/ThenTransformationPromiseCore.h
+++ b/include/eventkit/promise/detail/ThenTransformationPromiseCore.h
@@ -53,7 +53,7 @@ private:
 template <typename T, typename E, typename U, typename Handler>
 template <typename Tr>
 ThenTransformationPromiseCore<T, E, U, Handler>::ThenTransformationPromiseCore(ek::common::Allocator* pA, Tr&& transformation)
-    : PromiseCore<U, E>()
+    : PromiseCore<U, E>(pA)
     , m_transformation(std::forward<Tr>(transformation))
     , m_pA(pA)
     , m_intrusiveObjectMixin(deleteCallback, this)

--- a/include/eventkit/promise/detail/WhenAllTransformationPromiseCore.h
+++ b/include/eventkit/promise/detail/WhenAllTransformationPromiseCore.h
@@ -78,7 +78,8 @@ public:
     using Results = Result<std::vector<T>, E>;
 
     explicit DynamicWhenAllTransformationPromiseCore(ek::common::Allocator* pA, size_t size)
-        : m_values(size)
+        : PromiseCore<std::vector<T>, E>(pA)
+        , m_values(size)
         , m_fulfilledFlags(size, false)
         , m_pA(pA)
         , m_intrusiveObjectMixin(deleteCallback, this) {

--- a/include/eventkit/promise/detail/make_promise-inl.h
+++ b/include/eventkit/promise/detail/make_promise-inl.h
@@ -15,7 +15,7 @@ namespace detail {
 
 template<typename T, typename E>
 ek::promise::Promise<T, E> make_promise(const common::IntrusivePtr<PromiseCore<T, E>>& pCore) {
-    return ek::promise::Promise<T, E>(pCore);
+    return ek::promise::Promise<T, E>(pCore, nullptr);
 }
 
 }

--- a/include/eventkit/promise/global_functions/detail/whenAll-inl.h
+++ b/include/eventkit/promise/global_functions/detail/whenAll-inl.h
@@ -14,14 +14,14 @@ template <size_t Idx, typename Cr, typename LastPr>
 void addCoreAsHandlerToPromisesAt(const ek::common::IntrusivePtr<Cr>& pCore, LastPr&& lastPr) {
     lastPr.done(ek::promise::detail::make_function_observer<typename LastPr::Value, typename LastPr::Error>([pCore](const auto& result){
         pCore->template onResultAt<Idx>(result);
-    }));
+    }), nullptr);
 }
 
 template <size_t Idx, typename Cr, typename PrAtIndex, typename ...RestPrs>
 void addCoreAsHandlerToPromisesAt(const ek::common::IntrusivePtr<Cr>& pCore, PrAtIndex&& promiseAtIndex, RestPrs&& ...restPromises) {
     promiseAtIndex.done(ek::promise::detail::make_function_observer<typename PrAtIndex::Value, typename PrAtIndex::Error>([pCore](const auto& result){
         pCore->template onResultAt<Idx>(result);
-    }));
+    }), nullptr);
     addCoreAsHandlerToPromisesAt<Idx + 1>(pCore, std::forward<RestPrs>(restPromises)...);
 }
 

--- a/sample/promise_sample/main.cpp
+++ b/sample/promise_sample/main.cpp
@@ -59,23 +59,19 @@ int main(int argc, const char* argv[]) {
         }),
         Promise::value("!")
     }).then([](const std::vector<std::string>& texts) {
-        EK_USING_ALLOCATOR(ek::common::getDefaultAllocator());
         LOG("concatenating...");
         std::string concatenated = texts[0] + texts[1] + texts[2] + texts[3];
         return ek::promise::Promise<std::string, int>::value(concatenated);
     }).then([](const std::string& text) {
-        EK_USING_ALLOCATOR(ek::common::getDefaultAllocator());
         LOG("quoting...");
         std::stringstream ss;
         ss << "\"" << text << "\"";
         std::string quoted = ss.str();
         return ek::promise::Promise<std::string, int>::value(quoted);
     }).then([](const std::string& text) {
-        EK_USING_ALLOCATOR(ek::common::getDefaultAllocator());
         LOG("succeeded: ", text);
         return ek::promise::Promise<Unit, int>::value();
     }).recover([](int error) {
-        EK_USING_ALLOCATOR(ek::common::getDefaultAllocator());
         LOG("failed: ", error);
         return ek::promise::Promise<Unit, NoError>::value();
     }).done([](const ek::promise::Result<Unit, NoError>& result){

--- a/source/common/AllocatorStack.cpp
+++ b/source/common/AllocatorStack.cpp
@@ -1,0 +1,32 @@
+//
+// Created by Tsujita Masahiko on 2021/03/08.
+//
+
+#include <eventkit/common/AllocatorStack.h>
+
+#define EK_ALLOCATOR_STACK_SIZE (64)
+
+namespace ek {
+namespace common {
+
+thread_local Allocator* tl_allocatorStack[EK_ALLOCATOR_STACK_SIZE];
+thread_local Allocator** tl_ppAllocatorStackHead = tl_allocatorStack;
+thread_local Allocator* tl_pCurrentAllocator = nullptr;
+
+void pushAllocator(Allocator* pAllocator) {
+    *tl_ppAllocatorStackHead = pAllocator;
+    tl_ppAllocatorStackHead += 1;
+    tl_pCurrentAllocator = pAllocator;
+}
+
+void popAllocator() {
+    tl_ppAllocatorStackHead -= 1;
+    tl_pCurrentAllocator = *tl_ppAllocatorStackHead;
+}
+
+Allocator* getCurrentAllocator() {
+    return tl_pCurrentAllocator;
+}
+
+}
+}


### PR DESCRIPTION
- スレッドごとにスレッドローカルなアロケータを保持することによりインターフェースでのアロケータの受け渡しを不要にします
- スレッドローカルなアロケータはスタックで保持されておりpush, popが可能です
- コンストラクタ/デストラクタでアロケータのpush/popを行うRAIIアダプタ`AllocatorScope`を使うことにより安全にアロケータをpush/popできます
    - `EK_USING_ALLOCATOR()`マクロを使うことによりローカル変数名を明示的に指定することなく`AllocatorScope`を使うことができます
- `withAllocator()`関数を使うことによりpush/popで囲まれたラムダスコープを利用することができます
- 関数に渡したラムダがエスケープする場合、その関数呼び出しのスコープで設定されていたアロケータは、ラムダブロック内で利用可能であることは保証されません。
    - そのような関数を提供する場合は、関数呼び出し時に設定されたアロケータを保持して、ラムダの呼び出し時に再設定することが推奨されます。
- 注意: 現状アロケータスタックのサイズは64です。
- 現時点で、Promiseサブシステムの一部に導入されます。